### PR TITLE
README에서 KiwiTalk UI Mockup Figma 링크 교체

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## 프론트엔드
 
-- [KiwiTalk UI Mockup](https://www.figma.com/file/4Z6MR3oZK5iSvzyvvuT4DO/KiwiTalk-UI-Mockup?node-id=0%3A1)
+- [KiwiTalk UI Mockup](https://www.figma.com/file/JYO6jyz0Kji2KiPCW5cH5o/KiwiTalk-UI-Mockup-2?node-id=0%3A1)
 
 ## 주의사항
 


### PR DESCRIPTION
## 작업 내용 
- README의 KiwiTalk UI Mockup Figma 링크를 교체했습니다.
  - #1195 를 해결합니다.

## 배경
- Figma 파일 이동으로 링크가 비활성화 된 상태였는데, README에서 적절한 업데이트가 이루어지지 않았습니다.

## 링크
- [KiwiTalk UI Mockup](https://www.figma.com/file/JYO6jyz0Kji2KiPCW5cH5o/KiwiTalk-UI-Mockup-2?node-id=0%3A1)

## 기타 사항
- 추후 UI 목업의 전면 재작성이 이루어질 예정입니다. (폰트, 레이아웃, 컴포넌트 등)

## 희망 리뷰 완료 일  
- 2022.09.06(화)
