### PR TITLE
chore: Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,6 @@
 name: 버그 제보
 description: 예상치 못한 버그가 있다면 이곳으로 제보해주세요.
-labels: ["bug"]
+labels: ["Type: Bug"]
 assignees: []
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -34,7 +34,6 @@ body:
       required: true
   - type: input
     attributes:
-      id: kiwitalk-version
       label: 키위톡 버전
       description: 현재 사용중인 키위톡 버전, 혹은 커밋 해시를 제공해주세요.
       placeholder: 0.1.0
@@ -59,7 +58,6 @@ body:
       required: false
   - type: checkboxes
     attributes:
-      id: issure-requirements
       label: 현재 이슈와 같거나 비슷한 이슈가 있는지 찾아보셨나요?
       description: 아직 찾아보지 않았다면 [이슈 트래커](https://github.com/KiwiTalk/KiwiTalk/issues)에서 찾아보실 수 있습니다.
       options:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,70 @@
+name: Bug Report
+description: File a bug report
+title: ""
+labels: ["bug"]
+assignees: []
+body:
+  - type: textarea
+    attributes:
+      id: current-behavior
+      label: 현재 동작
+      description: 문제에 대한 간결하고 명확한 설명을 제공해주세요.
+      placeholder: |
+        ex) 오픈 채팅방에서 `내보내기` 버튼을 눌렀을 때 키위톡이 갑자기 꺼져요.
+    validation:
+      required: true
+  - type: textarea
+    attributes:
+      id: expected-behavior
+      label: 예상한 동작
+      description: 예상한 동작에 대해 간결하고 명확한 설명을 제공해주세요.
+      placeholder: |
+        ex) `내보내기` 버튼을 눌렀을 때 정상적으로 채팅방 멤버가 내보내져야해요.
+    validation:
+      required: true
+  - type: textarea
+    attributes:
+      id: step-to-reproduce
+      label: 재현 방법
+      description: 문제를 재현하는 방법을 가능한 자세히 설명해주세요. 명확하지 않거나 재현에 실패한 경우 이슈가 종료될 수 있습니다.
+      value: |
+        1. ...
+        2. ...
+        3. ...
+    validation:
+      required: true
+  - type: input
+    attributes:
+      id: kiwitalk-version
+      label: 키위톡 버전
+      description: 현재 사용중인 키위톡 버전, 혹은 커밋 해시를 제공해주세요.
+      placeholder: 0.1.0
+    validation:
+      required: true
+  - type: textarea
+    attributes:
+      id: os-specification
+      label: 운영 체제, 기타 실행 환경
+      description: 현재 사용중인 운영 체제, 운영 체제 버전, 기타 실행 환경을 제공해주세요.
+      value: |
+        OS: Ubuntu 22.04 / MacOS (Intel CPU / Apple Silicon) / Arch Linux / etc...
+        개발 버전 사용중: Yes/No
+    validation:
+      required: true
+  - type: textarea
+    attributes:
+      id: additional-notes
+      label: 추가 정보
+      description: 개발팀이 알아야하거나 필요한 정보가 있다면 이곳에 작성해주세요.
+    validation:
+      required: false
+  - type: checkboxes
+    attributes:
+      id: issure-requirements
+      label: 현재 이슈와 같거나 비슷한 이슈가 있는지 찾아보셨나요?
+      description: 아직 찾아보지 않았다면 [이슈 트래커](https://github.com/KiwiTalk/KiwiTalk/issues)에서 찾아보실 수 있습니다.
+      options:
+        - label: 현재 이슈와 동일한 이슈가 없는지 확인했습니다.
+          required: true
+        - label: 모든 필요한 정보를 정확히 제공했습니다.
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: File a bug report
-title: ""
 labels: ["bug"]
 assignees: []
 body:
@@ -11,7 +10,7 @@ body:
       description: 문제에 대한 간결하고 명확한 설명을 제공해주세요.
       placeholder: |
         ex) 오픈 채팅방에서 `내보내기` 버튼을 눌렀을 때 키위톡이 갑자기 꺼져요.
-    validation:
+    validations:
       required: true
   - type: textarea
     attributes:
@@ -20,7 +19,7 @@ body:
       description: 예상한 동작에 대해 간결하고 명확한 설명을 제공해주세요.
       placeholder: |
         ex) `내보내기` 버튼을 눌렀을 때 정상적으로 채팅방 멤버가 내보내져야해요.
-    validation:
+    validations:
       required: true
   - type: textarea
     attributes:
@@ -31,7 +30,7 @@ body:
         1. ...
         2. ...
         3. ...
-    validation:
+    validations:
       required: true
   - type: input
     attributes:
@@ -39,7 +38,7 @@ body:
       label: 키위톡 버전
       description: 현재 사용중인 키위톡 버전, 혹은 커밋 해시를 제공해주세요.
       placeholder: 0.1.0
-    validation:
+    validations:
       required: true
   - type: textarea
     attributes:
@@ -49,14 +48,14 @@ body:
       value: |
         OS: Ubuntu 22.04 / MacOS (Intel CPU / Apple Silicon) / Arch Linux / etc...
         개발 버전 사용중: Yes/No
-    validation:
+    validations:
       required: true
   - type: textarea
     attributes:
       id: additional-notes
       label: 추가 정보
       description: 개발팀이 알아야하거나 필요한 정보가 있다면 이곳에 작성해주세요.
-    validation:
+    validations:
       required: false
   - type: checkboxes
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,67 +1,60 @@
-name: 버그 제보
-description: 예상치 못한 버그가 있다면 이곳으로 제보해주세요.
+name: Bug report
+description: If you find unexpected behavior, or crashes, please report it to here. 
 labels: ["Type: Bug"]
 assignees: []
 body:
   - type: textarea
     attributes:
       id: current-behavior
-      label: 현재 동작
-      description: 문제에 대한 간결하고 명확한 설명을 제공해주세요.
+      label: Current behavior
+      description: Please provide a clear and concise description of the issue.
       placeholder: |
-        ex) 오픈 채팅방에서 `내보내기` 버튼을 눌렀을 때 키위톡이 갑자기 꺼져요.
+        ex) Client crashes when clicking X button
     validations:
       required: true
   - type: textarea
     attributes:
       id: expected-behavior
-      label: 예상한 동작
-      description: 예상한 동작에 대해 간결하고 명확한 설명을 제공해주세요.
+      label: Expected behavior
+      description: Please describe what you expected to happen.
       placeholder: |
-        ex) `내보내기` 버튼을 눌렀을 때 정상적으로 채팅방 멤버가 내보내져야해요.
+        ex) The X button should work normally.
     validations:
       required: true
   - type: textarea
     attributes:
       id: step-to-reproduce
-      label: 재현 방법
-      description: 문제를 재현하는 방법을 가능한 자세히 설명해주세요. 명확하지 않거나 재현에 실패한 경우 이슈가 종료될 수 있습니다.
+      label: Step to reproduce
+      description: Please provide a step to reproduce as much as you can. An issue which cannot be reproduced or invalid will be closed by maintainers.
       value: |
         1. ...
         2. ...
         3. ...
     validations:
       required: true
-  - type: input
-    attributes:
-      label: 키위톡 버전
-      description: 현재 사용중인 키위톡 버전, 혹은 커밋 해시를 제공해주세요.
-      placeholder: 0.1.0
-    validations:
-      required: true
   - type: textarea
     attributes:
       id: os-specification
-      label: 운영 체제, 기타 실행 환경
-      description: 현재 사용중인 운영 체제, 운영 체제 버전, 기타 실행 환경을 제공해주세요.
+      label: OS, or Other Environments
+      description: Please provide a detailed specification of your OS.
       value: |
         OS: Ubuntu 22.04 / MacOS (Intel CPU / Apple Silicon) / Arch Linux / etc...
-        개발 버전 사용중: Yes/No
+        Using Development build: Yes/No
     validations:
       required: true
   - type: textarea
     attributes:
       id: additional-notes
-      label: 추가 정보
-      description: 개발팀이 알아야하거나 필요한 정보가 있다면 이곳에 작성해주세요.
+      label: Additional Notes
+      description: If you have any additional notes, or things that maintainers should be aware of, Please write it here.
     validations:
       required: false
   - type: checkboxes
     attributes:
-      label: 현재 이슈와 같거나 비슷한 이슈가 있는지 찾아보셨나요?
-      description: 아직 찾아보지 않았다면 [이슈 트래커](https://github.com/KiwiTalk/KiwiTalk/issues)에서 찾아보실 수 있습니다.
+      label: Is there an existing issue for this?
+      description: Please search [here](https://github.com/KiwiTalk/KiwiTalk/issues) to see if an issue already exists for your problem.
       options:
-        - label: 현재 이슈와 동일한 이슈가 없는지 확인했습니다.
+        - label: I have searched the existing issues before opening this issue.
           required: true
-        - label: 모든 필요한 정보를 정확히 제공했습니다.
+        - label: I have provided all required informations.
           required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,5 +1,5 @@
-name: Bug Report
-description: File a bug report
+name: 버그 제보
+description: 예상치 못한 버그가 있다면 이곳으로 제보해주세요.
 labels: ["bug"]
 assignees: []
 body:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -39,6 +39,7 @@ body:
       description: Please provide a detailed specification of your OS.
       value: |
         OS: Ubuntu 22.04 / MacOS (Intel CPU / Apple Silicon) / Arch Linux / etc...
+        System Webview version: Windows (Edge) / MacOS (Safari)
         Using Development build: Yes/No
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,30 @@
+name: 기능 추가 요청
+description: 추가되었으면 좋은 기능들을 이곳에 요청해주세요.
+labels: ["Type: Enhancement"]
+assignees: []
+body:
+  - type: textarea
+    attributes:
+      id: feature
+      label: 추가하고 싶은 기능
+      description: 추가하고 싶은 기능이나 문제에 대한 간결하고 명확한 설명을 제공해주세요.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      id: solution
+      label: 해결 방법
+      description: 이 기능이 구현되기를 원하는 방식을 설명해주세요. 기술 구현 세부 사항은 필요하지 않으며, 이 기능이 어떻게 사용되기를 원하는지에 대한 설명이 필요합니다.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      id: additional-notes
+      label: 추가 정보
+      description: 기능 요청에 대한 다른 내용 또는 스크린샷, Proof-of-concepts 등을 추가해주세요.
+      value: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,27 +1,27 @@
-name: 기능 추가 요청
-description: 추가되었으면 좋은 기능들을 이곳에 요청해주세요.
+name: Feature Request
+description: Suggest a new feature or improvement for the software.
 labels: ["Type: Enhancement"]
 assignees: []
 body:
   - type: textarea
     attributes:
       id: feature
-      label: 추가하고 싶은 기능
-      description: 추가하고 싶은 기능이나 문제에 대한 간결하고 명확한 설명을 제공해주세요.
+      label: Describe the feature you would like to see.
+      description: Please provide a concise and clear description of the feature or issue you would like to see.
     validations:
       required: true
   - type: textarea
     attributes:
       id: solution
-      label: 해결 방법
-      description: 이 기능이 구현되기를 원하는 방식을 설명해주세요. 기술 구현 세부 사항은 필요하지 않으며, 이 기능이 어떻게 사용되기를 원하는지에 대한 설명이 필요합니다.
+      label: Describe the solution you'd like.
+      description: You must explain how you'd like to see this feature implemented. Technical implementation details are not necessary, rather an idea of how you'd like to see this feature used.
     validations:
       required: true
   - type: textarea
     attributes:
       id: additional-notes
-      label: 추가 정보
-      description: 기능 요청에 대한 다른 내용 또는 스크린샷, Proof-of-concepts 등을 추가해주세요.
+      label: Additional Notes
+      description: Add any other context, proof-of-concepts or screenshots about the feature request.
       value: |
         1. ...
         2. ...


### PR DESCRIPTION
최소한의 이슈 템플릿이 필요해보여서, GitHub Issue Forms 기능을 통해 제작하였습니다.

## Create Issues
![image](https://user-images.githubusercontent.com/32565818/195763745-937afc5d-f44b-430e-8821-7217b90866a2.png)

## 이슈 작성 화면
![image](https://user-images.githubusercontent.com/32565818/195763810-2b25f283-feff-41be-b599-bf3a4b2ab56a.png)

혹은, 제 [포크](https://github.com/alvin0319/KiwiTalk/issues) 레포지토리에서 직접 확인하실 수 있습니다.

## References
[GitHub Issue Forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms)