### PR TITLE
i18next의 폴백 언어를 한국어로 변경

### DIFF
--- a/frontend/src/app/env.ts
+++ b/frontend/src/app/env.ts
@@ -5,7 +5,7 @@ import { LangResource } from './intl';
 i18next.use(initReactI18next).init({
   resources: LangResource,
   debug: import.meta.env.DEV,
-  fallbackLng: 'en-US',
+  fallbackLng: 'ko-KR',
 
   interpolation: {
     escapeValue: false,


### PR DESCRIPTION
시스템 로캘이 영어인 경우 모든 문자열이 i18n 키 값(`login.login` 등)으로 표시되는 문제를 해결합니다.

카카오톡의 사용자가 대부분 한국어 가능자인 점, 키위톡 또한 한국어로 개발되고 있는 점, `en-US` 로캘의 값이 완전히 비어 있다는 점 등을 고려하면 폴백을 `ko-KR`로 바꾸는 것이 맞다고 생각됩니다.
