### PR TITLE
fix: downgrade rusqlite to 0.28.0

### DIFF
--- a/crates/kiwi-talk-client/Cargo.toml
+++ b/crates/kiwi-talk-client/Cargo.toml
@@ -15,7 +15,7 @@ bson = "2.6.1"
 log = "0.4.17"
 nohash-hasher = "0.2.0"
 smallvec = { version = "1.10.0", features = ["serde", "const_generics"] }
-rusqlite = { version = "0.29.0", features = ["bundled"] }
+rusqlite = { version = "0.28.0", features = ["bundled"] }
 rusqlite_migration = "1.0.2"
 r2d2 = "0.8.10"
 r2d2_sqlite = "0.21.0"


### PR DESCRIPTION
## Error Logs

```
~/programming/KiwiTalk/crates/kiwi-talk-client > cargo b
    Updating crates.io index
error: failed to select a version for `libsqlite3-sys`.
    ... required by package `rusqlite v0.28.0`
    ... which satisfies dependency `rusqlite = "^0.28"` of package `r2d2_sqlite v0.21.0`
    ... which satisfies dependency `r2d2_sqlite = "^0.21.0"` of package `kiwi-talk-client v0.1.0 (/home/dps0340/programming/KiwiTalk/crates/kiwi-talk-client)`
    ... which satisfies path dependency `kiwi-talk-client` (locked to 0.1.0) of package `kiwi-talk-app v0.1.0 (/home/dps0340/programming/KiwiTalk/crates/kiwi-talk-app)`
versions that meet the requirements `^0.25.0` are: 0.25.2, 0.25.1, 0.25.0

the package `libsqlite3-sys` links to the native library `sqlite3`, but it conflicts with a previous package which links to `sqlite3` as well:
package `libsqlite3-sys v0.26.0`
    ... which satisfies dependency `libsqlite3-sys = "^0.26.0"` of package `rusqlite v0.29.0`
    ... which satisfies dependency `rusqlite = "^0.29.0"` of package `kiwi-talk-client v0.1.0 (/home/dps0340/programming/KiwiTalk/crates/kiwi-talk-client)`
    ... which satisfies path dependency `kiwi-talk-client` (locked to 0.1.0) of package `kiwi-talk-app v0.1.0 (/home/dps0340/programming/KiwiTalk/crates/kiwi-talk-app)`
Only one package in the dependency graph may specify the same links value. This helps ensure that only one copy of a native library is linked in the final binary. Try to adjust your dependencies so that only one package uses the links ='libsqlite3-sys' value. For more information, see https://doc.rust-lang.org/cargo/reference/resolver.html#links.

failed to select a version for `libsqlite3-sys` which could resolve this conflict
```

## Analysis

`crates/kiwi-talk-client/Cargo.toml`
```toml
[dependencies]
# ...
rusqlite = { version = "0.29.0", features = ["bundled"] }
rusqlite_migration = "1.0.2"
r2d2 = "0.8.10"
r2d2_sqlite = "0.21.0"
```

`kiwi-talk-client` cargo에서 `r2d2_sqlite ^0.21.0`은 최신 버전이고, `rusqlite ^0.28.0`을 통해 `libsqlite3-sys ^0.25.0`을 요구하지만, 동일한 cargo의 `rusqlite 0.29.0` 버전은 `libsqlite3-sys ^0.26.0`을 요구합니다.
같은 `sys` dependency crate의 버전이 다를 경우 빌드가 되지 않아, links 정의 후 `build.rs`를 구축하거나 버전을 일치시켜야 합니다.

## Solutions

`rusqlite 0.28.0` 버전은 `libsqlite3-sys ^0.25.0`을 의존성으로 가지고 있어, 간단하게 0.28.0으로 다운그레이드시켰습니다.

## References

https://crates.io/crates/r2d2_sqlite/0.21.0/dependencies
https://crates.io/crates/rusqlite/0.29.0/dependencies

https://doc.rust-lang.org/cargo/reference/resolver.html#links
https://doc.rust-lang.org/cargo/reference/build-script-examples.html#linking-to-system-libraries