### PR TITLE
fix: primitive component state update

### DIFF
--- a/frontend/src/components/button/button.stories.tsx
+++ b/frontend/src/components/button/button.stories.tsx
@@ -1,6 +1,7 @@
 import { StoryFn } from 'storybook-solidjs';
 
 import { Button } from '.';
+import { ComponentProps } from 'solid-js';
 
 export default {
   title: 'KiwiTalk/Button',
@@ -10,7 +11,7 @@ export default {
   },
 };
 
-const Template: StoryFn<typeof Button> = (args) =>
+const Template: StoryFn<ComponentProps<typeof Button> & { text: string }> = (args) =>
   <Button disabled={args.disabled} onClick={args.onClick}>
     {args.text}
   </Button>;

--- a/frontend/src/components/check-box/check-box.stories.tsx
+++ b/frontend/src/components/check-box/check-box.stories.tsx
@@ -1,7 +1,6 @@
 import { StoryFn } from 'storybook-solidjs';
-import { ComponentProps } from 'react';
 
-import { CheckBox } from '.';
+import { CheckBox, CheckBoxStatus } from '.';
 
 export default {
   title: 'KiwiTalk/CheckBox',
@@ -11,15 +10,17 @@ export default {
   },
 };
 
-type AdditionalProp = {
+type Prop = {
   label: string,
+  disabled: boolean,
   checked?: boolean,
   indeterminate?: boolean,
+
+  onInput?: (status: CheckBoxStatus) => void,
 }
 
-const Template: StoryFn<ComponentProps<typeof CheckBox> & AdditionalProp> = (args) =>
+const Template: StoryFn<Prop> = (args) =>
   <CheckBox
-    id="example"
     disabled={args.disabled}
     status={{ checked: args.checked, indeterminate: args.indeterminate }}
     onInput={args.onInput}

--- a/frontend/src/components/check-box/check-box.stories.tsx
+++ b/frontend/src/components/check-box/check-box.stories.tsx
@@ -1,6 +1,7 @@
 import { StoryFn } from 'storybook-solidjs';
 
-import { CheckBox, CheckBoxStatus } from '.';
+import { CheckBox } from '.';
+import { ComponentProps } from 'solid-js';
 
 export default {
   title: 'KiwiTalk/CheckBox',
@@ -10,16 +11,13 @@ export default {
   },
 };
 
-type Prop = {
+type AdditionalProps = {
   label: string,
-  disabled: boolean,
   checked?: boolean,
   indeterminate?: boolean,
-
-  onInput?: (status: CheckBoxStatus) => void,
 }
 
-const Template: StoryFn<Prop> = (args) =>
+const Template: StoryFn<ComponentProps<typeof CheckBox> & AdditionalProps> = (args) =>
   <CheckBox
     disabled={args.disabled}
     status={{ checked: args.checked, indeterminate: args.indeterminate }}

--- a/frontend/src/components/check-box/index.tsx
+++ b/frontend/src/components/check-box/index.tsx
@@ -25,48 +25,59 @@ export type CheckBoxProp = ParentProps<{
   class?: string
 }>;
 
+type CheckBoxState = 'none' | 'checked' | 'indeterminate';
+
 export const CheckBox = (props: CheckBoxProp) => {
-  const [currentStatus, setCurrentStatus] = createSignal<CheckBoxStatus>({
-    checked: props.status?.checked ?? false,
-    indeterminate: props.status?.indeterminate ?? false,
-  });
+  const [state, setState] = createSignal<CheckBoxState>('none');
 
   function onInputChanged(input: HTMLInputElement) {
-    const nextStatus = {
+    props.onInput?.({
       checked: input.checked,
       indeterminate: input.indeterminate,
-    };
+    });
 
-    props.onInput?.(nextStatus);
-    setCurrentStatus(nextStatus);
+    if (input.indeterminate) {
+      setState('indeterminate');
+    } else if (input.checked) {
+      setState('checked');
+    } else {
+      setState('none');
+    }
   }
 
   createEffect(() => {
-    setCurrentStatus({
-      checked: props.status?.checked ?? false,
-      indeterminate: props.status?.indeterminate ?? false,
-    });
+    if (props.status) {
+      if (props.status.indeterminate) {
+        setState('indeterminate');
+      } else if (props.status.checked) {
+        setState('checked');
+      } else {
+        setState('none');
+      }
+    }
   });
 
   return <CheckBoxContainer data-disabled={props.disabled} class={props.class}>
     <CheckBoxLabel>
       <CheckBoxInput
         name={props.name}
-        checked={currentStatus().checked}
+        checked={state() === 'checked'}
         disabled={props.disabled}
         type="checkbox"
         ref={(ref) => {
-          if (!ref) return;
-          ref.indeterminate = currentStatus().indeterminate || false;
+          ref.indeterminate = state() === 'indeterminate';
         }}
         onInput={(e) => onInputChanged(e.currentTarget)}
       />
       <IconContainer>
-        <Switch fallback={<CheckBoxOutlineBlankSvg />}>
-          <Match when={currentStatus().indeterminate}>
+        <Switch>
+          <Match when={state() === 'none'}>
+            <CheckBoxOutlineBlankSvg />
+          </Match>
+          <Match when={state() === 'indeterminate'}>
             <CheckBoxIndeterminateSvg />
           </Match>
-          <Match when={currentStatus().checked}>
+          <Match when={state() === 'checked'}>
             <CheckBoxIconSvg />
           </Match>
         </Switch>
@@ -75,4 +86,3 @@ export const CheckBox = (props: CheckBoxProp) => {
     </CheckBoxLabel>
   </CheckBoxContainer>;
 };
-

--- a/frontend/src/components/input-form/index.tsx
+++ b/frontend/src/components/input-form/index.tsx
@@ -1,4 +1,4 @@
-import { JSX, Show, createSignal } from 'solid-js';
+import { JSX, Show, createEffect, createSignal } from 'solid-js';
 import { styled } from '../../utils';
 import { iconContainer, innerWrapper, input, inputBox } from './index.css';
 
@@ -23,7 +23,10 @@ type InputProp = {
 }
 
 export const InputForm = (props: InputProp) => {
-  const [activated, setActivated] = createSignal(!!props.value);
+  const [activated, setActivated] = createSignal(false);
+  createEffect(() => {
+    setActivated(!!props.value);
+  });
 
   function onInputHandler(element: HTMLInputElement) {
     if (props.maxLength && element.value.length > props.maxLength) {
@@ -35,8 +38,7 @@ export const InputForm = (props: InputProp) => {
   }
 
   function activateHandler(input: HTMLInputElement, shouldActivate: boolean) {
-    const nextState = !!input.value || shouldActivate;
-    if (activated() !== nextState) setActivated(nextState);
+    setActivated(shouldActivate || !!input.value);
   }
 
   return <InputBox

--- a/frontend/src/components/input-form/input.stories.tsx
+++ b/frontend/src/components/input-form/input.stories.tsx
@@ -16,7 +16,7 @@ const Template: StoryFn<typeof InputForm> = (args) =>
   <InputForm
     icon={args.icon}
     disabled={args.disabled}
-    defaultValue={args.defaultValue}
+    value={args.value}
     placeholder={args.placeholder}
     onInput={args.onInput}
   />;
@@ -25,14 +25,14 @@ export const Default = Template.bind({});
 Default.args = {
   icon: <IconAccountCircle />,
   disabled: false,
-  defaultValue: 'Sample input',
+  value: 'Sample input',
   placeholder: 'Placeholder',
 };
 
 export const WithoutIcon = Template.bind({});
 WithoutIcon.args = {
   disabled: false,
-  defaultValue: 'Sample input',
+  value: 'Sample input',
   placeholder: 'Placeholder',
 };
 
@@ -47,6 +47,6 @@ export const Disabled = Template.bind({});
 Disabled.args = {
   icon: <IconAccountCircle />,
   disabled: true,
-  defaultValue: 'Disabled input',
+  value: 'Disabled input',
   placeholder: 'Placeholder',
 };


### PR DESCRIPTION
기본 컴포넌트들의 `props`값 업데이트 로직을 수정합니다. #1904 참고

\+ 해당 컴포넌트들의 storybook에러를 고쳤습니다.

## 이전 작동 방식
`props` 값은 컴포넌트 생성시에만 반영됩니다.

## 변경된 작동 방식
`props`이 변경되었을때 state가 주어졌을 경우 해당 값으로 업데이트합니다.
* `CheckBox`의 경우 `status`
* `InputForm`의 경우 `value`
