### PR TITLE
feat: save window state

### DIFF
--- a/crates/kiwi-talk-app/Cargo.toml
+++ b/crates/kiwi-talk-app/Cargo.toml
@@ -38,6 +38,7 @@ nohash-hasher = "0.2.0"
 window-shadows = "0.2.1"
 num-bigint-dig = "0.8.4"
 anyhow = "1.0.75"
+tauri-plugin-window-state = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 
 [features]
 default = []

--- a/crates/kiwi-talk-app/src/main.rs
+++ b/crates/kiwi-talk-app/src/main.rs
@@ -52,6 +52,10 @@ async fn init_plugin(handle: &AppHandle<impl Runtime>) -> anyhow::Result<()> {
 fn on_tray_event(app: &AppHandle<impl Runtime>, event: SystemTrayEvent) {
     match event {
         SystemTrayEvent::LeftClick { .. } => {
+            if app.get_window("main").is_some() {
+                return;
+            }
+
             let main_window = create_main_window(app).unwrap();
             main_window.show().unwrap();
 

--- a/crates/kiwi-talk-app/src/main.rs
+++ b/crates/kiwi-talk-app/src/main.rs
@@ -77,7 +77,7 @@ async fn main() -> anyhow::Result<()> {
         dialog::message(
             Some(&main_window),
             "KiwiTalk Startup Fatal Error",
-            format!("{}", err),
+            format!("{:?}", err),
         );
     }
 

--- a/crates/kiwi-talk-app/src/main.rs
+++ b/crates/kiwi-talk-app/src/main.rs
@@ -10,8 +10,6 @@ mod constants;
 mod result;
 mod system;
 
-use std::error::Error;
-
 use tauri::{
     api::dialog, AppHandle, CustomMenuItem, Manager, Runtime, SystemTray, SystemTrayEvent,
     SystemTrayMenu,
@@ -27,7 +25,9 @@ fn init_logger() {
     builder.init();
 }
 
-async fn init_app(handle: &AppHandle<impl Runtime>) -> Result<(), Box<dyn Error + 'static>> {
+async fn init_app(handle: &AppHandle<impl Runtime>) -> anyhow::Result<()> {
+    handle.plugin(tauri_plugin_window_state::Builder::default().build())?;
+
     handle.plugin(system::init_plugin("system", handle.path_resolver()).await?)?;
     handle.plugin(configuration::init_plugin("configuration").await?)?;
     handle.plugin(auth::init_plugin("auth"))?;
@@ -57,7 +57,7 @@ fn on_tray_event(app: &AppHandle<impl Runtime>, event: SystemTrayEvent) {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error + 'static>> {
+async fn main() -> anyhow::Result<()> {
     init_logger();
 
     tauri::async_runtime::set(tokio::runtime::Handle::current());

--- a/crates/kiwi-talk-app/tauri.conf.json
+++ b/crates/kiwi-talk-app/tauri.conf.json
@@ -53,17 +53,6 @@
     "updater": {
       "active": false
     },
-    "windows": [
-      {
-        "fullscreen": false,
-        "width": 1280,
-        "height": 720,
-        "resizable": true,
-        "title": "KiwiTalk",
-        "decorations": false,
-        "label": "main"
-      }
-    ],
     "systemTray": {
       "iconPath": "icons/512x512.png",
       "iconAsTemplate": true

--- a/frontend/src/app/window/control.tsx
+++ b/frontend/src/app/window/control.tsx
@@ -1,5 +1,6 @@
 import { appWindow } from '@tauri-apps/api/window';
 import { ControlButtons, ControlType, WindowControl } from '../../components/window/control';
+import { saveWindowState, StateFlags } from 'tauri-plugin-window-state-api';
 
 export type AppWindowControlProp = {
   buttons?: ControlButtons;
@@ -10,7 +11,7 @@ export const AppWindowControl = (props: AppWindowControlProp) => {
   function onControlClick(type: ControlType) {
     switch (type) {
       case 'close': {
-        appWindow.close().then();
+        saveWindowState(StateFlags.ALL).then(() => appWindow.close()).then();
         break;
       }
 

--- a/frontend/src/app/window/control.tsx
+++ b/frontend/src/app/window/control.tsx
@@ -10,7 +10,7 @@ export const AppWindowControl = (props: AppWindowControlProp) => {
   function onControlClick(type: ControlType) {
     switch (type) {
       case 'close': {
-        appWindow.hide().then();
+        appWindow.close().then();
         break;
       }
 

--- a/package.json
+++ b/package.json
@@ -63,8 +63,7 @@
     "deepmerge-ts": "^5.1.0",
     "html-parse-string": "^0.0.9",
     "i18next": "23.5.1",
-    "solid-js": "^1.7.11",
-    "tauri-plugin-window-state-api": "github:tauri-apps/tauri-plugin-window-state#v1"
+    "solid-js": "^1.7.11"
   },
   "packageManager": "pnpm@8.7.6"
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "deepmerge-ts": "^5.1.0",
     "html-parse-string": "^0.0.9",
     "i18next": "23.5.1",
-    "solid-js": "^1.7.11"
+    "solid-js": "^1.7.11",
+    "tauri-plugin-window-state-api": "github:tauri-apps/tauri-plugin-window-state#v1"
   },
   "packageManager": "pnpm@8.7.6"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ dependencies:
   solid-js:
     specifier: ^1.7.11
     version: 1.7.11
+  tauri-plugin-window-state-api:
+    specifier: github:tauri-apps/tauri-plugin-window-state#v1
+    version: github.com/tauri-apps/tauri-plugin-window-state/5ea9eb0d4a9affd17269f92c0085935046be3f4a
 
 devDependencies:
   '@babel/core':
@@ -9369,3 +9372,11 @@ packages:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
     dev: true
+
+  github.com/tauri-apps/tauri-plugin-window-state/5ea9eb0d4a9affd17269f92c0085935046be3f4a:
+    resolution: {tarball: https://codeload.github.com/tauri-apps/tauri-plugin-window-state/tar.gz/5ea9eb0d4a9affd17269f92c0085935046be3f4a}
+    name: tauri-plugin-window-state-api
+    version: 0.0.0
+    dependencies:
+      '@tauri-apps/api': 1.4.0
+    dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,6 @@ dependencies:
   solid-js:
     specifier: ^1.7.11
     version: 1.7.11
-  tauri-plugin-window-state-api:
-    specifier: github:tauri-apps/tauri-plugin-window-state#v1
-    version: github.com/tauri-apps/tauri-plugin-window-state/5ea9eb0d4a9affd17269f92c0085935046be3f4a
 
 devDependencies:
   '@babel/core':
@@ -1476,13 +1473,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.22.13
-      '@babel/generator': 7.22.15
+      '@babel/generator': 7.23.0
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.22.5
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.22.16
-      '@babel/types': 7.22.19
+      '@babel/parser': 7.23.0
+      '@babel/types': 7.23.0
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
@@ -6784,7 +6781,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       '@babel/core': 7.23.0
-      '@babel/parser': 7.22.16
+      '@babel/parser': 7.23.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.1
@@ -9372,11 +9369,3 @@ packages:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
     dev: true
-
-  github.com/tauri-apps/tauri-plugin-window-state/5ea9eb0d4a9affd17269f92c0085935046be3f4a:
-    resolution: {tarball: https://codeload.github.com/tauri-apps/tauri-plugin-window-state/tar.gz/5ea9eb0d4a9affd17269f92c0085935046be3f4a}
-    name: tauri-plugin-window-state-api
-    version: 0.0.0
-    dependencies:
-      '@tauri-apps/api': 1.4.0
-    dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ dependencies:
   solid-js:
     specifier: ^1.7.11
     version: 1.7.11
+  tauri-plugin-window-state-api:
+    specifier: github:tauri-apps/tauri-plugin-window-state#v1
+    version: github.com/tauri-apps/tauri-plugin-window-state/5ea9eb0d4a9affd17269f92c0085935046be3f4a
 
 devDependencies:
   '@babel/core':
@@ -3512,10 +3515,10 @@ packages:
   /@storybook/csf-tools@7.5.0-alpha.3:
     resolution: {integrity: sha512-D7rk9mcyUXjJikmcmDghe4oJQXim7uKh2rxJP66lW1jD2Z5prkFzKbsYLbG57HGuly4ik4yox+Pd4r6w6QcCNQ==}
     dependencies:
-      '@babel/generator': 7.22.15
-      '@babel/parser': 7.22.16
-      '@babel/traverse': 7.22.20
-      '@babel/types': 7.22.19
+      '@babel/generator': 7.23.0
+      '@babel/parser': 7.23.0
+      '@babel/traverse': 7.23.0
+      '@babel/types': 7.23.0
       '@storybook/csf': 0.1.1
       '@storybook/types': 7.5.0-alpha.3
       fs-extra: 11.1.1
@@ -9369,3 +9372,11 @@ packages:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
     dev: true
+
+  github.com/tauri-apps/tauri-plugin-window-state/5ea9eb0d4a9affd17269f92c0085935046be3f4a:
+    resolution: {tarball: https://codeload.github.com/tauri-apps/tauri-plugin-window-state/tar.gz/5ea9eb0d4a9affd17269f92c0085935046be3f4a}
+    name: tauri-plugin-window-state-api
+    version: 0.0.0
+    dependencies:
+      '@tauri-apps/api': 1.4.0
+    dev: false


### PR DESCRIPTION
## Features
* `tauri_plugin_window_state`를 사용하여 키위톡 윈도우 위치와 상태를 저장합니다.
* 사용자가 창을 닫았을시 창을 숨기는게 아니라 실제로 닫아 메모리 사용량을 줄입니다.
* `SystemInfo`에서 device_data_dir 필드를 제거하고 config_dir을 추가 했습니다. (device_data_dir은 tauri에서 제공하는 `PathResolver`를 사용하여 얻을 수 있으므로 필요하지 않음)