### PR TITLE
fix: Make tauri command return types to match ts.

### DIFF
--- a/.github/workflows/rustfmt-pr.yml
+++ b/.github/workflows/rustfmt-pr.yml
@@ -3,6 +3,9 @@ on:
     paths:
       - '**.rs'
 
+permissions:
+  pull-requests: write
+
 name: rustfmt
 jobs:
   review:

--- a/backend/bin/auth/src/lib.rs
+++ b/backend/bin/auth/src/lib.rs
@@ -3,8 +3,9 @@ mod constants;
 use anyhow::Context;
 use kiwi_talk_result::TauriResult;
 use sha2::{Digest, Sha512};
-use talk_api_client::auth::{
-    xvc::XVCHasher, AccountLoginForm, AuthClientConfig, AuthDeviceConfig, TalkAuthClient,
+use talk_api_client::{
+    auth::{xvc::XVCHasher, AccountLoginForm, AuthClientConfig, AuthDeviceConfig, TalkAuthClient},
+    response::TalkStatusResponse,
 };
 use tauri::{
     generate_handler,
@@ -42,15 +43,14 @@ pub fn create_auto_login_token(
 }
 
 #[tauri::command(async)]
-async fn request_passcode(email: String, password: String) -> TauriResult<i32> {
+async fn request_passcode(email: String, password: String) -> TauriResult<TalkStatusResponse<()>> {
     Ok(create_auth_client()
         .request_passcode(AccountLoginForm {
             email: &email,
             password: &password,
         })
         .await
-        .context("request_passcode request failed")?
-        .status)
+        .context("request_passcode request failed")?)
 }
 
 #[tauri::command(async)]
@@ -59,7 +59,7 @@ async fn register_device(
     email: String,
     password: String,
     permanent: bool,
-) -> TauriResult<i32> {
+) -> TauriResult<TalkStatusResponse<()>> {
     Ok(create_auth_client()
         .register_device(
             &passcode,
@@ -70,8 +70,7 @@ async fn register_device(
             permanent,
         )
         .await
-        .context("register_device request failed")?
-        .status)
+        .context("register_device request failed")?)
 }
 
 pub fn create_auth_client() -> TalkAuthClient<'static, impl XVCHasher> {

--- a/backend/bin/auth/src/lib.rs
+++ b/backend/bin/auth/src/lib.rs
@@ -3,9 +3,8 @@ mod constants;
 use anyhow::Context;
 use kiwi_talk_result::TauriResult;
 use sha2::{Digest, Sha512};
-use talk_api_client::{
-    auth::{xvc::XVCHasher, AccountLoginForm, AuthClientConfig, AuthDeviceConfig, TalkAuthClient},
-    response::TalkStatusResponse,
+use talk_api_client::auth::{
+    xvc::XVCHasher, AccountLoginForm, AuthClientConfig, AuthDeviceConfig, TalkAuthClient,
 };
 use tauri::{
     generate_handler,
@@ -43,14 +42,15 @@ pub fn create_auto_login_token(
 }
 
 #[tauri::command(async)]
-async fn request_passcode(email: String, password: String) -> TauriResult<TalkStatusResponse<()>> {
+async fn request_passcode(email: String, password: String) -> TauriResult<i32> {
     Ok(create_auth_client()
         .request_passcode(AccountLoginForm {
             email: &email,
             password: &password,
         })
         .await
-        .context("request_passcode request failed")?)
+        .context("request_passcode request failed")?
+        .status)
 }
 
 #[tauri::command(async)]
@@ -59,7 +59,7 @@ async fn register_device(
     email: String,
     password: String,
     permanent: bool,
-) -> TauriResult<TalkStatusResponse<()>> {
+) -> TauriResult<i32> {
     Ok(create_auth_client()
         .register_device(
             &passcode,
@@ -70,7 +70,8 @@ async fn register_device(
             permanent,
         )
         .await
-        .context("register_device request failed")?)
+        .context("register_device request failed")?
+        .status)
 }
 
 pub fn create_auth_client() -> TalkAuthClient<'static, impl XVCHasher> {

--- a/frontend/src/app/login/content/device-register.tsx
+++ b/frontend/src/app/login/content/device-register.tsx
@@ -20,9 +20,9 @@ export const DeviceRegisterContent = (props: DeviceRegisterContentProp) => {
     if (data.loading) return;
 
     try {
-      const res = await requestPasscode(props.input.email, props.input.password);
+      const status = await requestPasscode(props.input.email, props.input.password);
 
-      props.onSubmit?.(res.status, type);
+      props.onSubmit?.(status, type);
     } catch (e) {
       props.onError?.(e);
     }

--- a/frontend/src/app/login/content/index.tsx
+++ b/frontend/src/app/login/content/index.tsx
@@ -101,6 +101,7 @@ export const AppLoginContent = (props: LoginContentProp) => {
   });
 
   function onLoginSubmit(input: LoginFormInput, status: number) {
+    setInput(input);
     switch (status) {
       case 0: {
         props.onLogin?.();
@@ -118,7 +119,6 @@ export const AppLoginContent = (props: LoginContentProp) => {
       }
     }
 
-    setInput(input);
     setState({ ...state(), errorMessage: `login.status.login.${status}` });
   }
 

--- a/frontend/src/app/login/content/passcode.tsx
+++ b/frontend/src/app/login/content/passcode.tsx
@@ -19,14 +19,14 @@ export const PasscodeContent = (props: PasscodeContentProp) => {
     if (data.loading) return;
 
     try {
-      const res = await registerDevice(
+      const status = await registerDevice(
           passcode,
           props.input.email,
           props.input.password,
           props.registerType === 'permanent',
       );
 
-      props.onSubmit?.(res.status);
+      props.onSubmit?.(status);
     } catch (e) {
       props.onError?.(e);
     }

--- a/frontend/src/ipc/auth.ts
+++ b/frontend/src/ipc/auth.ts
@@ -1,13 +1,7 @@
 import { tauri } from '@tauri-apps/api';
 
-export type TalkResponseStatus<T = void> = {
-  status: number,
-} | {
-  status: 0
-} & T
-
-export function requestPasscode(email: string, password: string): Promise<TalkResponseStatus> {
-  return tauri.invoke<TalkResponseStatus>('plugin:auth|request_passcode', {
+export function requestPasscode(email: string, password: string): Promise<number> {
+  return tauri.invoke<number>('plugin:auth|request_passcode', {
     email,
     password,
   });
@@ -18,8 +12,8 @@ export function registerDevice(
   email: string,
   password: string,
   permanent: boolean,
-): Promise<TalkResponseStatus> {
-  return tauri.invoke<TalkResponseStatus>('plugin:auth|register_device', {
+): Promise<number> {
+  return tauri.invoke<number>('plugin:auth|register_device', {
     passcode,
     email,
     password,


### PR DESCRIPTION
## Description

- request_passcode, register_device command 의 리턴 타입을 타입스크립트에서 기대하는 타입과 일치시킵니다.
  - https://github.com/KiwiTalk/KiwiTalk/blob/032b45b09010c11ec324ce0c13134877454b8cd7/backend/bin/auth/src/lib.rs#L45
  - https://github.com/KiwiTalk/KiwiTalk/blob/032b45b09010c11ec324ce0c13134877454b8cd7/frontend/src/ipc/auth.ts#L9
  - https://github.com/KiwiTalk/KiwiTalk/blob/032b45b09010c11ec324ce0c13134877454b8cd7/backend/bin/auth/src/lib.rs#L57-L62
  - https://github.com/KiwiTalk/KiwiTalk/blob/032b45b09010c11ec324ce0c13134877454b8cd7/frontend/src/ipc/auth.ts#L16-L21
- request_passcode 에 email, password 가 빈 문자열로 넘어가는 문제를 해결합니다.