### PR TITLE
1분 주기로 서버에 핑 패킷 전송

### DIFF
--- a/backend/bin/app/src/client/mod.rs
+++ b/backend/bin/app/src/client/mod.rs
@@ -27,7 +27,7 @@ use talk_loco_client::{
     futures_loco_protocol::{session::LocoSession, LocoClient},
     talk::stream::TalkStream,
 };
-use tokio::{sync::mpsc, task::JoinHandle, time::interval};
+use tokio::{sync::mpsc, task::JoinHandle, time::sleep};
 
 use kiwi_talk_result::{TauriAnyhowError, TauriResult};
 use kiwi_talk_system::get_system_info;
@@ -443,10 +443,8 @@ async fn create_client(
         let session = session.clone();
 
         async move {
-            let mut timer = interval(Duration::from_secs(60));
-
             loop {
-                timer.tick().await;
+                sleep(Duration::from_secs(60)).await;
 
                 if session.send_ping().await.is_err() {
                     return;

--- a/backend/crates/kiwi-talk-client/src/lib.rs
+++ b/backend/crates/kiwi-talk-client/src/lib.rs
@@ -25,8 +25,8 @@ use futures::TryStreamExt;
 use serde::{Deserialize, Serialize};
 use talk_loco_client::{
     futures_loco_protocol::session::LocoSession,
-    talk::session::{LChatListReq, LoginListReq, SetStReq, TalkSession},
-    RequestError,
+    talk::session::{LChatListReq, LoginListReq, PingReq, SetStReq, TalkSession},
+    RequestError, RequestResult,
 };
 use thiserror::Error;
 
@@ -44,6 +44,10 @@ impl KiwiTalkSession {
 
     pub const fn channel(&self, id: ChannelId) -> ClientChannel {
         ClientChannel::new(id, self)
+    }
+
+    pub async fn send_ping(&self) -> RequestResult<()> {
+        TalkSession(&self.session).ping(&PingReq {}).await
     }
 
     pub async fn channel_list(&self) -> Result<Vec<(ChannelId, ChannelListData)>, PoolTaskError> {

--- a/backend/crates/talk-loco-client/src/talk/session/mod.rs
+++ b/backend/crates/talk-loco-client/src/talk/session/mod.rs
@@ -21,6 +21,8 @@ use futures_lite::Stream;
 impl_session!(
     #[derive(Debug)]
     pub struct TalkSession {
+        pub fn ping("PING", struct PingReq {});
+
         pub fn set_status("SETST", struct SetStReq {
             /// Status
             ///


### PR DESCRIPTION
## Description
1분 주기로 핑을 날려 접속이 끊어지는 문제를 해결합니다.
<!--
Write description of PR here. If you're fixing a specific issue, write "Fixes #xxxx".
-->

## Changelog
* `TalkSession`에 `ping`메서드 추가
* `Client`에 `ping_task` 필드 추가

<!--
(Optional)

If this PR is not bug fixes, write list of changes here.
-->

## Migration

<!--
(Optional)

If this PR contains breaking changes, describe migration guide.
- Fixing unintended behaviour is not a breaking changes.
- Adding new functionality is not a breaking change.
-->