### PR TITLE
TalkNormalChannel::users 메서드 제거

### DIFF
--- a/backend/bin/client/src/channel.rs
+++ b/backend/bin/client/src/channel.rs
@@ -220,7 +220,7 @@ pub(super) async fn channel_users(
 
     match &*channel {
         ClientChannel::Normal(_, users) => Ok(users
-            .into_iter()
+            .iter()
             .cloned()
             .map(|(id, user)| (id.to_string(), NormalChannelUser::from(user)))
             .collect()),

--- a/backend/bin/client/src/channel.rs
+++ b/backend/bin/client/src/channel.rs
@@ -219,14 +219,11 @@ pub(super) async fn channel_users(
     let channel = map.get(rid)?;
 
     match &*channel {
-        ClientChannel::Normal(normal) => {
-            let users = normal.users().await.context("cannot load users")?;
-
-            Ok(users
-                .into_iter()
-                .map(|(id, user)| (id.to_string(), NormalChannelUser::from(user)))
-                .collect())
-        }
+        ClientChannel::Normal(_, users) => Ok(users
+            .into_iter()
+            .cloned()
+            .map(|(id, user)| (id.to_string(), NormalChannelUser::from(user)))
+            .collect()),
 
         _ => Err(anyhow!("unsupported channel types").into()),
     }

--- a/backend/crates/headless-talk/src/channel/mod.rs
+++ b/backend/crates/headless-talk/src/channel/mod.rs
@@ -26,7 +26,10 @@ use talk_loco_client::talk::{
     session::{channel::write, TalkSession},
 };
 
-use self::{normal::{NormalChannel, user::NormalChannelUser}, open::OpenChannel};
+use self::{
+    normal::{user::NormalChannelUser, NormalChannel},
+    open::OpenChannel,
+};
 
 pub type ChannelMetaMap = IntMap<i32, ChannelMeta>;
 

--- a/backend/crates/headless-talk/src/channel/mod.rs
+++ b/backend/crates/headless-talk/src/channel/mod.rs
@@ -26,9 +26,11 @@ use talk_loco_client::talk::{
     session::{channel::write, TalkSession},
 };
 
-use self::{normal::NormalChannel, open::OpenChannel};
+use self::{normal::{NormalChannel, user::NormalChannelUser}, open::OpenChannel};
 
 pub type ChannelMetaMap = IntMap<i32, ChannelMeta>;
+
+pub type UserList<T> = Vec<(i64, T)>;
 
 #[derive(Debug, Clone)]
 pub struct ListPreviewChat {
@@ -59,21 +61,21 @@ pub struct ChannelListItem {
 
 #[derive(Debug)]
 pub enum ClientChannel {
-    Normal(NormalChannel),
+    Normal(NormalChannel, UserList<NormalChannelUser>),
     Open(OpenChannel),
 }
 
 impl ClientChannel {
     pub const fn id(&self) -> i64 {
         match self {
-            ClientChannel::Normal(normal) => normal.id(),
+            ClientChannel::Normal(normal, _) => normal.id(),
             ClientChannel::Open(open) => open.id(),
         }
     }
 
     const fn conn(&self) -> &Conn {
         match self {
-            ClientChannel::Normal(normal) => &normal.conn,
+            ClientChannel::Normal(normal, _) => &normal.conn,
             ClientChannel::Open(open) => &open.conn,
         }
     }
@@ -128,7 +130,7 @@ impl ClientChannel {
 
     pub async fn read_chat(&self, watermark: i64) -> ClientResult<()> {
         let (id, pool) = match self {
-            ClientChannel::Normal(normal) => {
+            ClientChannel::Normal(normal, _) => {
                 let id = normal.id();
                 let conn = &normal.conn;
 
@@ -253,7 +255,7 @@ impl ClientChannel {
         let conn = self.conn();
 
         match self {
-            ClientChannel::Normal(_) => {
+            ClientChannel::Normal(_, _) => {
                 TalkSession(&conn.session)
                     .normal_channel(id)
                     .leave(block)

--- a/backend/crates/headless-talk/src/lib.rs
+++ b/backend/crates/headless-talk/src/lib.rs
@@ -85,15 +85,17 @@ impl HeadlessTalk {
             ChatOnChannelType::DirectChat(normal)
             | ChatOnChannelType::MultiChat(normal)
             | ChatOnChannelType::MemoChat(normal) => {
-                ClientChannel::Normal(normal::open_channel(id, self, normal).await?)
+                let (channel, user_list) =
+                    normal::open_channel(id, self, res.active_user_ids.clone(), normal).await?;
+                ClientChannel::Normal(channel, user_list)
             }
 
             _ => return Ok(None),
         };
 
-        if let (Some(active_user_ids), Some(watermarks)) = (res.active_user_ids, res.watermarks) {
-            let active_user_count = active_user_ids.len() as i32;
-            let watermark_iter = active_user_ids.into_iter().zip(watermarks.into_iter());
+        if let Some(watermarks) = res.watermarks {
+            let active_user_count = res.active_user_ids.len() as i32;
+            let watermark_iter = res.active_user_ids.into_iter().zip(watermarks.into_iter());
 
             self.conn
                 .pool

--- a/backend/crates/talk-loco-client/src/talk/session/channel/chat_on.rs
+++ b/backend/crates/talk-loco-client/src/talk/session/channel/chat_on.rs
@@ -13,7 +13,7 @@ pub struct ChatOnChannel {
 
     /// Also watermark user ids
     #[serde(rename = "a")]
-    pub active_user_ids: Option<Vec<i64>>,
+    pub active_user_ids: Vec<i64>,
 
     #[serde(rename = "w")]
     pub watermarks: Option<Vec<i64>>,


### PR DESCRIPTION
## Description
`TalkNormalChannel::users` 메서드 제거
<!--
Write description of PR here. If you're fixing a specific issue, write "Fixes #xxxx".
-->

## Changelog
* `TalkNormalChannel::users` 메서드 제거
* `HeadlessTalk::open_channel` 메서드 호출시 현재 채팅방 인원들에 대한 유저 정보만 반환
<!--
(Optional)

If this PR is not bug fixes, write list of changes here.
-->

## Migration

<!--
(Optional)

If this PR contains breaking changes, describe migration guide.
- Fixing unintended behaviour is not a breaking changes.
- Adding new functionality is not a breaking change.
-->