### PR TITLE
fix(main): disable `transparent` effect on Linux

### DIFF
--- a/backend/bin/app/src/main.rs
+++ b/backend/bin/app/src/main.rs
@@ -32,9 +32,7 @@ fn create_main_window<R: Runtime>(manager: &impl Manager<R>) -> anyhow::Result<W
     // TODO: see https://github.com/tauri-apps/tao/issues/470 (original winit supports `window.set_blur(true)`)
     let window = window_builder.build()?;
     #[cfg(not(target_os = "linux"))]
-    let window = window_builder
-        .transparent(true)
-        .build()?;
+    let window = window_builder.transparent(true).build()?;
 
     #[cfg(target_os = "macos")]
     #[allow(deprecated)]

--- a/backend/bin/app/src/main.rs
+++ b/backend/bin/app/src/main.rs
@@ -30,8 +30,7 @@ fn create_main_window<R: Runtime>(manager: &impl Manager<R>) -> anyhow::Result<W
 
     #[cfg(target_os = "linux")]
     // TODO: see https://github.com/tauri-apps/tao/issues/470 (original winit supports `window.set_blur(true)`)
-    let window = window_builder
-        .build()?;
+    let window = window_builder.build()?;
     #[cfg(not(target_os = "linux"))]
     let window = window_builder
         .transparent(true)

--- a/backend/bin/app/src/main.rs
+++ b/backend/bin/app/src/main.rs
@@ -21,12 +21,19 @@ use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial};
 use window_vibrancy::apply_acrylic;
 
 fn create_main_window<R: Runtime>(manager: &impl Manager<R>) -> anyhow::Result<Window<R>> {
-    let window = WindowBuilder::new(manager, "main", tauri::WindowUrl::App("index.html".into()))
+    let window_builder = WindowBuilder::new(manager, "main", tauri::WindowUrl::App("index.html".into()))
         .inner_size(1280.0, 720.0)
         .resizable(true)
         .title("KiwiTalk")
         .decorations(false)
-        .visible(false)
+        .visible(false);
+
+    #[cfg(target_os = "linux")]
+    // TODO: see https://github.com/tauri-apps/tao/issues/470 (original winit supports `window.set_blur(true)`)
+    let window = window_builder
+        .build()?;
+    #[cfg(not(target_os = "linux"))]
+    let window = window_builder
         .transparent(true)
         .build()?;
 

--- a/backend/bin/app/src/main.rs
+++ b/backend/bin/app/src/main.rs
@@ -21,12 +21,13 @@ use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial};
 use window_vibrancy::apply_acrylic;
 
 fn create_main_window<R: Runtime>(manager: &impl Manager<R>) -> anyhow::Result<Window<R>> {
-    let window_builder = WindowBuilder::new(manager, "main", tauri::WindowUrl::App("index.html".into()))
-        .inner_size(1280.0, 720.0)
-        .resizable(true)
-        .title("KiwiTalk")
-        .decorations(false)
-        .visible(false);
+    let window_builder =
+        WindowBuilder::new(manager, "main", tauri::WindowUrl::App("index.html".into()))
+            .inner_size(1280.0, 720.0)
+            .resizable(true)
+            .title("KiwiTalk")
+            .decorations(false)
+            .visible(false);
 
     #[cfg(target_os = "linux")]
     // TODO: see https://github.com/tauri-apps/tao/issues/470 (original winit supports `window.set_blur(true)`)


### PR DESCRIPTION
## Description

- see https://github.com/tauri-apps/tao/issues/470
- winit은 `set_blur(bool)`을 지원하나, tao는 아직 지원하고 있지 않음
- 리눅스 환경에서만 투명화 효과를 임시 비활성화 (tao에 `set_blur` 지원이 추가될 때까지)

## Changelog

- disable `transparent` on Linux