### PR TITLE
viewModel 리팩토링

### DIFF
--- a/frontend/src/pages/_components/window-controls/window-controls.stories.tsx
+++ b/frontend/src/pages/_components/window-controls/window-controls.stories.tsx
@@ -1,6 +1,6 @@
 import { StoryFn } from 'storybook-solidjs';
 
-import { WindowControls, WindowControlsViewModelType } from './window-controls';
+import { WindowControls } from './window-controls';
 import * as styles from './window-controls.stories.css';
 
 export default {
@@ -9,17 +9,9 @@ export default {
 };
 
 const Template: StoryFn<{ isActive: boolean }> = (props) => {
-  const isActive = () => props.isActive;
-  const NoOpViewModel: WindowControlsViewModelType = () => ({
-    onMinimize: () => {},
-    onMaximize: () => {},
-    onClose: () => {},
-    isActive,
-  });
-
   return (
     <div class={styles.background}>
-      <WindowControls viewModel={NoOpViewModel}/>
+      <WindowControls isActive={props.isActive} />
     </div>
   );
 };

--- a/frontend/src/pages/_components/window-controls/window-controls.tsx
+++ b/frontend/src/pages/_components/window-controls/window-controls.tsx
@@ -1,49 +1,19 @@
 import { useTransContext } from '@jellybrick/solid-i18next';
-import { appWindow } from '@tauri-apps/api/window';
-import { Accessor, createResource, mergeProps, onCleanup, untrack } from 'solid-js';
-import { saveWindowState, StateFlags } from 'tauri-plugin-window-state-api';
 
 import * as styles from './window-controls.css';
 
-export type WindowControlsViewModelType = () => {
-  isActive: Accessor<boolean>;
-  onMinimize: () => void;
-  onMaximize: () => void;
-  onClose: () => void;
-};
-
-export const WindowControlsViewModel: WindowControlsViewModelType = () => {
-  const [isFocused, { mutate: mutateIsFocused }] = createResource(
-    () => appWindow.isFocused(),
-  );
-
-  const [unlisten] = createResource(
-    () => appWindow.onFocusChanged(({ payload: focused }) => mutateIsFocused(focused)),
-  );
-
-  onCleanup(() => unlisten()?.());
-
-  return {
-    isActive: () => isFocused() ?? true,
-    onMinimize: () => appWindow.minimize(),
-    onMaximize: () => appWindow.toggleMaximize(),
-    onClose: async () => {
-      await saveWindowState(StateFlags.ALL);
-      await appWindow.close();
-    },
-  };
-};
-
 type WindowControlsProps = {
-  viewModel?: WindowControlsViewModelType
+  isActive?: boolean;
+
+  onMinimize?: () => void;
+  onMaximize?: () => void;
+  onClose?: () => void;
 };
 
 export const WindowControls = (props: WindowControlsProps) => {
-  const merged = mergeProps({ viewModel: WindowControlsViewModel }, props);
-  const instance = untrack(() => merged.viewModel());
   const [t] = useTransContext();
 
-  const buttonVariant = () => instance.isActive() ? 'active' : 'inactive';
+  const buttonVariant = () => props.isActive ? 'active' : 'inactive';
 
   return (
     <div data-tauri-drag-region class={styles.container}>
@@ -52,19 +22,19 @@ export const WindowControls = (props: WindowControlsProps) => {
         <button
           aria-label={t('window-controls.minimize')}
           class={styles.buttonMinMax[buttonVariant()]}
-          onClick={instance.onMinimize}
+          onClick={props.onMinimize}
           type="button"
         />
         <button
           aria-label={t('window-controls.maximize')}
           class={styles.buttonMinMax[buttonVariant()]}
-          onClick={instance.onMaximize}
+          onClick={props.onMaximize}
           type="button"
         />
         <button
           aria-label={t('window-controls.close')}
           class={styles.buttonClose[buttonVariant()]}
-          onClick={instance.onClose}
+          onClick={props.onClose}
           type="button"
         />
       </div>

--- a/frontend/src/pages/layout.tsx
+++ b/frontend/src/pages/layout.tsx
@@ -1,13 +1,16 @@
-import { ParentProps } from 'solid-js';
+import { ParentProps, createResource, onCleanup } from 'solid-js';
+import { Router, Routes, hashIntegration } from '@solidjs/router';
+import { Transition } from 'solid-transition-group';
+import { appWindow } from '@tauri-apps/api/window';
 
 import { I18nProvider } from '@/features/i18n';
 import { ConfigProvider } from '@/features/config';
+import { classes, themeRoot } from '@/features/theme';
 
 import { WindowControls } from './_components/window-controls';
-import { Router, Routes, hashIntegration } from '@solidjs/router';
-import { classes, themeRoot } from '@/features/theme';
-import { container } from './layout.css';
-import { Transition } from 'solid-transition-group';
+
+import * as styles from './layout.css';
+import { saveWindowState, StateFlags } from 'tauri-plugin-window-state-api';
 
 export const Provider = (props: ParentProps) => (
   <I18nProvider>
@@ -17,22 +20,46 @@ export const Provider = (props: ParentProps) => (
   </I18nProvider>
 );
 
-export const Layout = (props: ParentProps) => (
-  <Provider>
-    <Router source={hashIntegration()}>
-      <div
-        classList={{
-          [themeRoot]: true,
-          [container]: true,
-        }}
-      >
-        <WindowControls />
-        <Transition appear mode={'outin'} {...classes.transition.scale}>
-          <Routes>
-            {props.children}
-          </Routes>
-        </Transition>
-      </div>
-    </Router>
-  </Provider>
-);
+export const Layout = (props: ParentProps) => {
+  const [isFocused, { mutate: mutateIsFocused }] = createResource(
+    () => appWindow.isFocused(),
+  );
+
+  const [unlisten] = createResource(
+    () => appWindow.onFocusChanged(({ payload: focused }) => mutateIsFocused(focused)),
+  );
+
+  const onMinimize = () => appWindow.minimize();
+  const onMaximize = () => appWindow.toggleMaximize();
+  const onClose = async () => {
+    await saveWindowState(StateFlags.ALL);
+    await appWindow.close();
+  };
+
+  onCleanup(() => unlisten()?.());
+
+  return (
+    <Provider>
+      <Router source={hashIntegration()}>
+        <div
+          classList={{
+            [themeRoot]: true,
+            [styles.container]: true,
+          }}
+        >
+          <WindowControls
+            isActive={isFocused()}
+            onMinimize={onMinimize}
+            onMaximize={onMaximize}
+            onClose={onClose}
+          />
+          <Transition appear mode={'outin'} {...classes.transition.scale}>
+            <Routes>
+              {props.children}
+            </Routes>
+          </Transition>
+        </div>
+      </Router>
+    </Provider>
+  );
+};

--- a/frontend/src/pages/main/_components/sidebar/sidebar.stories.tsx
+++ b/frontend/src/pages/main/_components/sidebar/sidebar.stories.tsx
@@ -1,14 +1,7 @@
-import { createSignal } from 'solid-js';
+import { createSignal, onMount } from 'solid-js';
 import { StoryFn } from 'storybook-solidjs';
 
-import IconChat from '@/assets/icons/chat.svg';
-import IconNotification from '@/assets/icons/notification.svg';
-import IconNotificationOff from '@/assets/icons/notification_off.svg';
-import IconOpenChat from '@/assets/icons/openchat.svg';
-import IconSettings from '@/assets/icons/settings.svg';
-import IconUsers from '@/assets/icons/users.svg';
-
-import { Sidebar, SidebarPathType, SidebarViewModelType } from './sidebar';
+import { Sidebar, SidebarPathType } from './sidebar';
 import * as styles from './sidebar.stories.css';
 
 export default {
@@ -18,35 +11,26 @@ export default {
 
 const Template: StoryFn<{ collapsed: boolean }> = (props) => {
   const [activePath, setActivePath] = createSignal<SidebarPathType>('friends');
-  const NoOpViewModel: SidebarViewModelType<SidebarPathType> = () => {
-    const [isNotificationActive, setIsNotificationActive] = createSignal(false);
+  const [notificationActive, setNotificationActive] = createSignal(false);
+  const [badges, setBadges] = createSignal<[string, string]>(['...', '...']);
 
-    return {
-      topItems: () => [
-        { kind: 'tab', icon: <IconUsers />, path: 'friends' },
-        { kind: 'tab', icon: <IconChat />, path: 'chat', badge: 6 },
-        { kind: 'tab', icon: <IconOpenChat />, path: 'openchat', badge: 12 },
-      ],
-      bottomItems: () => [
-        {
-          kind: 'toggle',
-          iconOn: <IconNotification />,
-          iconOff: <IconNotificationOff />,
-          isActive: isNotificationActive,
-          setIsActive: setIsNotificationActive,
-        },
-        { kind: 'tab', icon: <IconSettings />, path: 'settings' },
-      ],
-    };
-  };
+  onMount(() => {
+    setTimeout(() => {
+      setBadges(['1', '2']);
+    }, 500);
+  });
 
   return (
     <div class={styles.background}>
       <Sidebar
+        collapsed={props.collapsed}
         activePath={activePath()}
         setActivePath={setActivePath}
-        collapsed={props.collapsed}
-        viewModel={NoOpViewModel}
+
+        chatBadges={badges()[0]}
+        openChatBadges={badges()[1]}
+        notificationActive={notificationActive()}
+        onNotificationActive={setNotificationActive}
       />
     </div>
   );

--- a/frontend/src/pages/main/_components/sidebar/sidebar.tsx
+++ b/frontend/src/pages/main/_components/sidebar/sidebar.tsx
@@ -1,26 +1,19 @@
 import {
-  Accessor,
   For,
   JSX,
   Match,
   Show,
   Switch,
-  createResource,
-  createSignal,
   mergeProps,
   splitProps,
-  untrack,
 } from 'solid-js';
 
-import { getChannelList } from '@/api/client/client';
-import { useReady } from '@/pages/main/_hooks';
-
 import IconChat from '@/assets/icons/chat.svg';
-import IconNotification from '@/assets/icons/notification.svg';
-import IconNotificationOff from '@/assets/icons/notification_off.svg';
+import IconUsers from '@/assets/icons/users.svg';
 import IconOpenChat from '@/assets/icons/openchat.svg';
 import IconSettings from '@/assets/icons/settings.svg';
-import IconUsers from '@/assets/icons/users.svg';
+import IconNotification from '@/assets/icons/notification.svg';
+import IconNotificationOff from '@/assets/icons/notification_off.svg';
 
 import * as styles from './sidebar.css';
 
@@ -30,7 +23,6 @@ type SidebarButtonProps = {
   badge?: JSX.Element;
   onClick: () => void;
 };
-
 const SidebarButton = (props: SidebarButtonProps) => (
   <button
     type="button"
@@ -50,7 +42,6 @@ type SidebarToggleProps = {
   iconOn: JSX.Element;
   iconOff: JSX.Element;
 };
-
 const SidebarToggle = (props: SidebarToggleProps) => (
   <label class={styles.sidebarToggle[props.isActive ? 'active' : 'inactive']}>
     <input
@@ -72,53 +63,53 @@ const SidebarToggle = (props: SidebarToggleProps) => (
 );
 
 export type SidebarPathType = 'friends' | 'chat' | 'openchat' | 'settings';
-export type SidebarTabType<Path extends string> = {
+export type SidebarTabType = {
   kind: 'tab';
-  icon: JSX.Element,
-  badge?: JSX.Element,
-  path: Path,
+  icon: JSX.Element;
+  badge?: string | number;
+  path: SidebarPathType;
 };
 
 export type SidebarToggleType = {
   kind: 'toggle';
   iconOn: JSX.Element;
   iconOff: JSX.Element;
-  isActive: Accessor<boolean>;
+  isActive: boolean;
   setIsActive: (isActive: boolean) => void;
 };
 
-type SidebarItemType<Path extends string> = SidebarTabType<Path> | SidebarToggleType;
-type SidebarItemsProps<Path extends string> = {
-  activePath: Path;
-  setActivePath: (path: Path) => void;
-  items: SidebarItemType<Path>[];
+type SidebarItemType = SidebarTabType | SidebarToggleType;
+type SidebarItemsProps = {
+  activePath: string;
+  setActivePath: (path: string) => void;
+  items: SidebarItemType[];
 };
 
-const SidebarItems = <Path extends string>(props: SidebarItemsProps<Path>) => (
+const SidebarItems = (props: SidebarItemsProps) => (
   <div class={styles.sidebarItems}>
     <For each={props.items}>
       {(item) => (
         <Switch>
           {/* Tab */}
-          <Match when={item.kind === 'tab' ? item : null}>
+          <Match keyed when={item.kind === 'tab' ? item : null}>
             {(tab) => (
               <SidebarButton
-                badge={tab().badge}
-                icon={tab().icon}
-                isActive={tab().path === props.activePath}
-                onClick={() => props.setActivePath(tab().path)}
+                badge={tab.badge}
+                icon={tab.icon}
+                isActive={tab.path === props.activePath}
+                onClick={() => props.setActivePath(tab.path)}
               />
             )}
           </Match>
 
           {/* Toggle */}
-          <Match when={item.kind === 'toggle' ? item : null}>
+          <Match keyed when={item.kind === 'toggle' ? item : null}>
             {(toggle) => (
               <SidebarToggle
-                iconOn={toggle().iconOn}
-                iconOff={toggle().iconOff}
-                isActive={toggle().isActive()}
-                setIsActive={toggle().setIsActive}
+                iconOn={toggle.iconOn}
+                iconOff={toggle.iconOff}
+                isActive={toggle.isActive}
+                setIsActive={toggle.setIsActive}
               />
             )}
           </Match>
@@ -128,70 +119,63 @@ const SidebarItems = <Path extends string>(props: SidebarItemsProps<Path>) => (
   </div>
 );
 
-export type SidebarViewModelType<Path extends string> = () => {
-  topItems: Accessor<SidebarItemType<Path>[]>;
-  bottomItems: Accessor<SidebarItemType<Path>[]>;
-};
+type SidebarProps = {
+  collapsed?: boolean;
+  activePath: string;
+  setActivePath: (path: string) => void;
 
-export const SidebarViewModel: SidebarViewModelType<SidebarPathType> = () => {
-  const isReady = useReady();
+  chatBadges?: string | number;
+  openChatBadges?: string | number;
+  notificationActive?: boolean;
+  onNotificationActive?: (notificationActive: boolean) => void;
+}
 
-  // FIXME create @/features/config and migrate to useConfiguration
-  const [isNotificationActive, setIsNotificationActive] = createSignal(false);
-
-  const [badges] = createResource(isReady, async (isReady) => {
-    if (!isReady) return ['...', '...'];
-
-    let chatBadge = 0;
-    let openChatBadge = 0;
-
-    for (const [, item] of await getChannelList()) {
-      // TODO: add open chat badge
-      chatBadge += item.unreadCount;
-      openChatBadge += 0;
-    }
-
-    return [chatBadge, openChatBadge];
-  });
-
-  return {
-    topItems: () => [
-      { kind: 'tab', icon: <IconUsers />, path: 'friends' },
-      { kind: 'tab', icon: <IconChat />, path: 'chat', badge: badges()?.[0] ?? '...' },
-      { kind: 'tab', icon: <IconOpenChat />, path: 'openchat', badge: badges()?.[1] ?? '...' },
-    ],
-    bottomItems: () => [
-      {
-        kind: 'toggle',
-        iconOn: <IconNotification />,
-        iconOff: <IconNotificationOff />,
-        isActive: isNotificationActive,
-        setIsActive: setIsNotificationActive,
-      },
-      { kind: 'tab', icon: <IconSettings />, path: 'settings' },
-    ],
-  };
-};
-
-type SidebarProps<Path extends string> =
-  & { collapsed?: boolean }
-  & Omit<SidebarItemsProps<Path>, 'items'>
-  & (
-    SidebarPathType extends Path
-      ? { viewModel?: SidebarViewModelType<Path> }
-      : { viewModel: SidebarViewModelType<Path> }
+export const Sidebar = (props: SidebarProps) => {
+  const [itemsProps, local] = splitProps(
+    mergeProps({ notificationActive: false, onNotificationActive: () => {} }, props),
+    ['activePath', 'setActivePath'],
   );
 
-export const Sidebar = <Path extends string = SidebarPathType>(props: SidebarProps<Path>) => {
-  const [itemsProps] = splitProps(props, ['activePath', 'setActivePath']);
-  const merged = mergeProps({ viewModel: SidebarViewModel as SidebarViewModelType<Path> }, props);
-  const instance = untrack(() => merged.viewModel());
+  const topItems = (): SidebarItemType[] => [
+    {
+      kind: 'tab',
+      icon: <IconUsers />,
+      path: 'friends',
+    },
+    {
+      kind: 'tab',
+      icon: <IconChat />,
+      path: 'chat',
+      badge: props.chatBadges ?? '...',
+    },
+    {
+      kind: 'tab',
+      icon: <IconOpenChat />,
+      path: 'openchat',
+      badge: props.openChatBadges ?? '...',
+    },
+  ];
+
+  const bottomItems = (): SidebarItemType[] => [
+    {
+      kind: 'toggle',
+      iconOn: <IconNotification />,
+      iconOff: <IconNotificationOff />,
+      isActive: local.notificationActive,
+      setIsActive: local.onNotificationActive,
+    },
+    {
+      kind: 'tab',
+      icon: <IconSettings />,
+      path: 'settings',
+    },
+  ];
 
   return (
     <aside class={styles.sidebar[props.collapsed ? 'collapsed' : 'default']}>
-      <SidebarItems items={instance.topItems()} {...itemsProps} />
+      <SidebarItems items={topItems()} {...itemsProps} />
       <Show when={!props.collapsed}>
-        <SidebarItems items={instance.bottomItems()} {...itemsProps} />
+        <SidebarItems items={bottomItems()} {...itemsProps} />
       </Show>
     </aside>
   );

--- a/frontend/src/pages/main/_hooks/index.ts
+++ b/frontend/src/pages/main/_hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './useReady';
 export * from './useEvent';
+export * from './useSidebar';

--- a/frontend/src/pages/main/_hooks/useReady.tsx
+++ b/frontend/src/pages/main/_hooks/useReady.tsx
@@ -15,6 +15,7 @@ const ReadyContext = createContext<Accessor<boolean>>(() => false);
 export const useReady = () => useContext(ReadyContext);
 
 export type ReadyProviderProps = ParentProps<{
+  onReady?: () => void;
   onLogout?: (reason: LogoutReason) => void;
   onEvent?: (event: KiwiTalkMainEvent) => void;
 }>;
@@ -27,6 +28,7 @@ export const ReadyProvider = (props: ReadyProviderProps) => {
       await create('Unlocked');
     }
     setIsReady(true);
+    props.onReady?.();
 
     const stream = createMainEventStream();
 

--- a/frontend/src/pages/main/_hooks/useSidebar.ts
+++ b/frontend/src/pages/main/_hooks/useSidebar.ts
@@ -1,0 +1,37 @@
+import { Accessor, createSignal, createResource } from 'solid-js';
+import { getChannelList } from '@/api';
+
+export const useSidebar = (isReady: Accessor<boolean>) => {
+  // FIXME create @/features/config and migrate to useConfiguration
+  const [isNotificationActive, setIsNotificationActive] = createSignal(false);
+
+  const [badges] = createResource(isReady, async (isReady) => {
+    if (!isReady) {
+      return {
+        chat: '...',
+        open: '...',
+      };
+    }
+
+    let chatBadge = 0;
+    let openChatBadge = 0;
+
+    for (const [, item] of await getChannelList()) {
+      // TODO: add open chat badge
+      chatBadge += item.unreadCount;
+      openChatBadge += 0;
+    }
+
+    return {
+      chat: chatBadge,
+      open: openChatBadge,
+    };
+  });
+
+  return {
+    badges: () => badges(),
+
+    notificationActive: () => isNotificationActive(),
+    setNotificationActive: (active: boolean) => setIsNotificationActive(active),
+  };
+};

--- a/frontend/src/pages/main/channel/_components/channel-list/channel-list.stories.tsx
+++ b/frontend/src/pages/main/channel/_components/channel-list/channel-list.stories.tsx
@@ -1,11 +1,9 @@
+import { createSignal } from 'solid-js';
 import { StoryFn } from 'storybook-solidjs';
 
 import * as styles from './channel-list.stories.css';
-import { ChannelList, ChannelListProps, ChannelListViewModelType } from './channel-list';
+import { ChannelList, ChannelListProps } from './channel-list';
 
-import IconSearch from '@/assets/icons/search.svg';
-import IconAddChat from '@/pages/main/channel/_assets/icons/add-chat.svg';
-import { createSignal } from 'solid-js';
 import { ListProfile } from '../../_types/channel-list-item';
 
 export default {
@@ -20,47 +18,36 @@ const Template: StoryFn<ChannelListProps> = () => {
       profileUrl: `https://picsum.photos/200?s=${Math.random()}`,
     }] as [string, ListProfile]);
 
-  const NoOpViewModel: ChannelListViewModelType = () => ({
-    channels: () => Array.from({ length: 10 }).map((_, index) => {
-      const userLength = 2 + Math.floor(Math.random() * 10);
-      const displayUsers = getUsers(userLength);
+  const channelList = () => Array.from({ length: 10 }).map((_, index) => {
+    const userLength = 2 + Math.floor(Math.random() * 10);
+    const displayUsers = getUsers(userLength);
 
-      const lastChat = {
-        chatType: 0,
-        nickname: displayUsers[Math.floor(Math.random() * userLength)][1].nickname,
-        content: 'last message',
-        timestamp: new Date(),
-      };
+    const lastChat = {
+      chatType: 0,
+      nickname: displayUsers[Math.floor(Math.random() * userLength)][1].nickname,
+      content: 'last message',
+      timestamp: new Date(),
+    };
 
-      return {
-        id: `${index}`,
-        displayUsers,
+    return {
+      id: `${index}`,
+      displayUsers,
 
-        lastChat: Math.random() > 0.2 ? lastChat : undefined,
+      lastChat: Math.random() > 0.2 ? lastChat : undefined,
 
-        name: `Channel ${index + 1}`,
-        unreadCount: Math.floor(Math.random() * 10),
-        userCount: displayUsers.length,
-        silent: Math.random() > 0.5,
-      };
-    }),
-    topItems: () => [
-      {
-        kind: 'click',
-        icon: <IconSearch />,
-      },
-      {
-        kind: 'click',
-        icon: <IconAddChat />,
-      },
-    ],
+      name: `Channel ${index + 1}`,
+      unreadCount: Math.floor(Math.random() * 10),
+      userCount: displayUsers.length,
+      silent: Math.random() > 0.5,
+    };
   });
+
   const [activeId, setActiveId] = createSignal('1');
 
   return (
     <div class={styles.background}>
       <ChannelList
-        viewModel={NoOpViewModel}
+        channels={channelList()}
         activeId={activeId()}
         setActiveId={setActiveId}
       />

--- a/frontend/src/pages/main/channel/_hooks/index.ts
+++ b/frontend/src/pages/main/channel/_hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useChannelList';

--- a/frontend/src/pages/main/channel/_hooks/useChannelList.ts
+++ b/frontend/src/pages/main/channel/_hooks/useChannelList.ts
@@ -1,0 +1,43 @@
+import { Accessor, createResource } from 'solid-js';
+
+import { getChannelList } from '@/api';
+import { useReady, useEvent } from '@/pages/main/_hooks';
+
+import { ChannelListItem } from '../_types';
+
+export const useChannelList = (): Accessor<ChannelListItem[]> => {
+  const isReady = useReady();
+  const event = useEvent();
+
+  let cached: ChannelListItem[] = [];
+  const [channelMap] = createResource(
+    () => [isReady(), event()] as const,
+    async ([isReady, event]) => {
+      if (!isReady) return [];
+      if (event?.type !== 'chat' && cached.length > 0) return cached;
+
+      const result: ChannelListItem[] = [];
+
+      for (const [id, item] of await getChannelList()) {
+        result.push({
+          id,
+          name: item.name ?? item.displayUsers.map(([, user]) => user.nickname).join(', '),
+          displayUsers: item.displayUsers,
+          lastChat: item.lastChat ? {
+            ...item.lastChat,
+            timestamp: new Date(item.lastChat.timestamp),
+          } : undefined,
+          userCount: item.userCount,
+          unreadCount: item.unreadCount,
+          profile: item.profile,
+          silent: false, // TODO
+        });
+      }
+
+      cached = result;
+      return result;
+    },
+  );
+
+  return () => channelMap() ?? [];
+};

--- a/frontend/src/pages/main/channel/page.tsx
+++ b/frontend/src/pages/main/channel/page.tsx
@@ -1,12 +1,14 @@
 import { Outlet, useNavigate, useParams } from '@solidjs/router';
 
-import { ChannelList, ChannelListViewModel } from './_components/channel-list';
+import { ChannelList } from './_components/channel-list';
+import { useChannelList } from './_hooks';
 
 import * as styles from './page.css';
 
 export const ChannelListPage = () => {
   const navigate = useNavigate();
   const param = useParams();
+  const channelList = useChannelList();
 
   const activeId = () => param.channelId;
   const setActiveId = (id: string) => {
@@ -17,7 +19,7 @@ export const ChannelListPage = () => {
     <div class={styles.container}>
       <div class={styles.list}>
         <ChannelList
-          viewModel={ChannelListViewModel}
+          channels={channelList()}
           activeId={activeId()}
           setActiveId={setActiveId}
         />

--- a/frontend/src/pages/main/friend/_components/friend-list/friend-list.stories.tsx
+++ b/frontend/src/pages/main/friend/_components/friend-list/friend-list.stories.tsx
@@ -1,12 +1,9 @@
 import { StoryFn } from 'storybook-solidjs';
 
 import * as styles from './friend-list.stories.css';
-import { FriendList, FriendListProps, FriendListViewModelType } from './friend-list';
+import { FriendList, FriendListProps } from './friend-list';
 
 import { FriendProfile, LogonProfile } from '@/api';
-
-import IconSearch from '@/assets/icons/search.svg';
-import IconAddUser from '@/pages/main/friend/_assets/icons/add-user.svg';
 
 export default {
   title: 'KiwiTalk v2/Friend/Friend List',
@@ -47,28 +44,16 @@ const Template: StoryFn<FriendListProps> = () => {
 
     profileImageUrl: Math.random() > 0.2 ? `https://picsum.photos/200?s=${Math.random()}` : '',
   }));
-
-  const NoOpViewModel: FriendListViewModelType = () => ({
-    me: () => me,
-    all: () => allFriends,
-    pinned: () => allFriends.slice(0, 3),
-    nearBirthday: () => allFriends.slice(3, 10),
-    topItems: () => [
-      {
-        kind: 'click',
-        icon: <IconSearch />,
-      },
-      {
-        kind: 'click',
-        icon: <IconAddUser />,
-      },
-    ],
-  });
+  const pinned = allFriends.slice(0, 3);
+  const nearBirthday = allFriends.slice(3, 10);
 
   return (
     <div class={styles.background}>
       <FriendList
-        viewModel={NoOpViewModel}
+        me={me}
+        pinned={pinned}
+        nearBirthday={nearBirthday}
+        all={allFriends}
       />
     </div>
   );

--- a/frontend/src/pages/main/friend/_hooks/index.ts
+++ b/frontend/src/pages/main/friend/_hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useFriendList';

--- a/frontend/src/pages/main/friend/_hooks/useFriendList.ts
+++ b/frontend/src/pages/main/friend/_hooks/useFriendList.ts
@@ -1,0 +1,32 @@
+import { createResource } from 'solid-js';
+
+import { FriendProfile, updateFriends } from '@/api';
+
+import { useReady } from '../../_hooks';
+
+export const useFriendList = () => {
+  const isReady = useReady();
+
+  const [friends] = createResource([] as FriendProfile[], async (list) => {
+    if (!isReady) return list;
+
+    const res = await updateFriends(list.map((friend) => friend.userId));
+
+    for (const removed of res.removedIds) {
+      const index = list.findIndex((friend) => friend.userId === removed);
+      list.splice(index, 1);
+    }
+
+    for (const added of res.added) {
+      list.push(added);
+    }
+
+    return list;
+  });
+
+  return {
+    all: (() => friends() ?? []),
+    pinned: () => [], // TODO: implement
+    nearBirthday: () => [], // TODO: implement
+  };
+};

--- a/frontend/src/pages/main/friend/page.tsx
+++ b/frontend/src/pages/main/friend/page.tsx
@@ -1,14 +1,33 @@
 import { Outlet } from '@solidjs/router';
 
-import { FriendList, FriendListViewModel } from './_components/friend-list/friend-list';
+import { FriendList } from './_components/friend-list/friend-list';
 
 import * as styles from './page.css';
+import { useFriendList } from './_hooks';
+import { createResource } from 'solid-js';
+import { useReady } from '../_hooks';
+import { meProfile } from '@/api';
 
 export const FriendListPage = () => {
+  const isReady = useReady();
+
+  const friendList = useFriendList();
+  const [me] = createResource(async () => {
+    if (!isReady) return undefined;
+
+    return meProfile();
+  });
+
+
   return (
     <div class={styles.container}>
       <div class={styles.list}>
-        <FriendList viewModel={FriendListViewModel} />
+        <FriendList
+          me={me()}
+          pinned={friendList.pinned()}
+          nearBirthday={friendList.nearBirthday()}
+          all={friendList.all()}
+        />
       </div>
       <Outlet />
     </div>

--- a/frontend/src/pages/main/page.tsx
+++ b/frontend/src/pages/main/page.tsx
@@ -1,20 +1,22 @@
+import { createSignal } from 'solid-js';
 import { Outlet, useLocation, useNavigate } from '@solidjs/router';
 
 import { KiwiTalkMainEvent, LogoutReason } from '@/api';
 import { destroy } from '@/api/client/client';
 
 import { Sidebar } from './_components/sidebar';
+import { ReadyProvider, EventContext, useSidebar } from './_hooks';
 
 import * as styles from './page.css';
-import { ReadyProvider } from './_hooks/useReady';
-import { EventContext } from './_hooks/useEvent';
-import { createSignal } from 'solid-js';
 
 export const MainPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
+  const [isReady, setIsReady] = createSignal(false);
   const [listeners, setListeners] = createSignal<((event: KiwiTalkMainEvent) => void)[]>([]);
+
+  const sidebar = useSidebar(isReady);
 
   const activeTab = () => location.pathname.match(/main\/([^/]+)/)?.[1] ?? 'chat';
   const setActiveTab = (tab: string) => {
@@ -44,13 +46,18 @@ export const MainPage = () => {
         setListeners(newList);
       },
     }}>
-      <ReadyProvider onLogout={onLogout} onEvent={onEvent}>
+      <ReadyProvider onLogout={onLogout} onEvent={onEvent} onReady={() => setIsReady(true)}>
         <main class={styles.container}>
           <div class={styles.sidebarWrapper}>
             <Sidebar
               collapsed={false}
               activePath={activeTab()}
               setActivePath={setActiveTab}
+
+              chatBadges={sidebar.badges()?.chat}
+              openChatBadges={sidebar.badges()?.open}
+              notificationActive={sidebar.notificationActive()}
+              onNotificationActive={sidebar.setNotificationActive}
             />
           </div>
           <Outlet />


### PR DESCRIPTION
## Description
`viewModel`을 사용하는 컴포넌트를 리팩토링합니다.

## Changelog
- 리팩토링 기준은 다음과 같습니다
  - `viewModel`: 제거
  - 단순 getter: `props`로 통합
  - 단순 setter: `props`에 `onName` 이벤트로 통합
  - `API`를 호출하며 실제 데이터를 넣는 코드: `useName`형식의 hook으로 분리
  - storybook: `viewModel`

## Migration

<!--
(Optional)

If this PR contains breaking changes, describe migration guide.
- Fixing unintended behaviour is not a breaking changes.
- Adding new functionality is not a breaking change.
-->