### PR TITLE
단일 인스턴스만 실행 허용

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2170,6 +2170,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-log",
+ "tauri-plugin-single-instance",
  "tauri-plugin-window-state",
  "tokio",
  "window-shadows",
@@ -4404,7 +4405,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-log"
 version = "0.0.0"
-source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v1#444a16ca73618cb562edcd46e2fc4a6e2f08f7e2"
+source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v1#8d6045421a553330e9da8b9e1e4405d419c5ea88"
 dependencies = [
  "byte-unit",
  "fern",
@@ -4417,9 +4418,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "0.0.0"
+source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v1#8d6045421a553330e9da8b9e1e4405d419c5ea88"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror",
+ "windows-sys 0.48.0",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-plugin-window-state"
 version = "0.1.0"
-source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v1#444a16ca73618cb562edcd46e2fc4a6e2f08f7e2"
+source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v1#8d6045421a553330e9da8b9e1e4405d419c5ea88"
 dependencies = [
  "bincode",
  "bitflags 2.4.1",

--- a/backend/bin/app/Cargo.toml
+++ b/backend/bin/app/Cargo.toml
@@ -33,6 +33,7 @@ window-shadows = "0.2.2"
 tauri-plugin-window-state = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 tauri-plugin-log = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 window-vibrancy = "0.4.2"
+tauri-plugin-single-instance = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 
 [features]
 default = []

--- a/backend/bin/app/src/main.rs
+++ b/backend/bin/app/src/main.rs
@@ -6,6 +6,7 @@
 mod configuration;
 
 use kiwi_talk_system::get_system_info;
+use log::info;
 use tauri::{
     api::dialog, AppHandle, CustomMenuItem, DeviceEventFilter, Manager, RunEvent, Runtime,
     SystemTray, SystemTrayEvent, SystemTrayMenu, Window, WindowBuilder,
@@ -73,6 +74,12 @@ async fn init_plugin(handle: &AppHandle<impl Runtime>) -> anyhow::Result<()> {
             .build(),
     )?;
     handle.plugin(tauri_plugin_window_state::Builder::default().build())?;
+    handle.plugin(tauri_plugin_single_instance::init(|app, argv, cwd| {
+        info!(
+            "app: {} argv: {argv:?} cwd: {cwd:?}",
+            &app.package_info().name
+        );
+    }))?;
 
     handle.plugin(kiwi_talk_api::init().await)?;
     handle.plugin(configuration::init_plugin("configuration").await?)?;


### PR DESCRIPTION
## Description
파일 손상등을 막기 위해 키위톡 인스턴스를 하나 이상 동시에 킬수 없도록 합니다.
<!--
Write description of PR here. If you're fixing a specific issue, write "Fixes #xxxx".
-->

## Changelog
* `tauri-plugin-single-instance` 추가
<!--
(Optional)

If this PR is not bug fixes, write list of changes here.
-->

## Migration

<!--
(Optional)

If this PR contains breaking changes, describe migration guide.
- Fixing unintended behaviour is not a breaking changes.
- Adding new functionality is not a breaking change.
-->