### PR TITLE
1:1 채팅의 프로필 이미지에 채팅 상대의 프로필 이미지를 폴백으로 사용 외

### DIFF
--- a/backend/bin/client/src/channel_list.rs
+++ b/backend/bin/client/src/channel_list.rs
@@ -1,5 +1,5 @@
 use arrayvec::ArrayVec;
-use headless_talk::channel::ListPreviewChat;
+use headless_talk::channel::{ListChannelProfileImage, ListPreviewChat};
 use serde::Serialize;
 
 use kiwi_talk_result::TauriResult;
@@ -49,7 +49,7 @@ pub(crate) struct ChannelListItem {
     last_chat: Option<PreviewChat>,
 
     name: String,
-    profile: Option<String>,
+    profile: Option<ProfileImage>,
 
     user_count: i32,
     unread_count: i32,
@@ -66,9 +66,25 @@ impl From<headless_talk::channel::ChannelListItem> for ChannelListItem {
                 .collect::<ArrayVec<_, 4>>(),
             last_chat: item.last_chat.map(PreviewChat::from),
             name: item.profile.name,
-            profile: item.profile.image_url,
+            profile: item.profile.image.map(ProfileImage::from),
             user_count: item.active_user_count,
             unread_count: item.unread_count,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileImage {
+    pub image_url: String,
+    pub full_image_url: String,
+}
+
+impl From<ListChannelProfileImage> for ProfileImage {
+    fn from(image: ListChannelProfileImage) -> Self {
+        Self {
+            image_url: image.image_url,
+            full_image_url: image.full_image_url,
         }
     }
 }

--- a/backend/crates/headless-talk/src/channel/mod.rs
+++ b/backend/crates/headless-talk/src/channel/mod.rs
@@ -19,6 +19,7 @@ use diesel::{
     QueryDsl, RunQueryDsl,
 };
 use nohash_hasher::IntMap;
+use serde::Deserialize;
 use talk_loco_client::talk::{
     channel::{ChannelMeta, ChannelType},
     chat::{Chat, ChatType, Chatlog},
@@ -40,7 +41,14 @@ pub struct ListPreviewChat {
 #[derive(Debug, Clone)]
 pub struct ListChannelProfile {
     pub name: String,
-    pub image_url: Option<String>,
+    pub image: Option<ListChannelProfileImage>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListChannelProfileImage {
+    pub image_url: String,
+    pub full_image_url: String,
 }
 
 #[derive(Debug, Clone)]

--- a/backend/crates/headless-talk/src/channel/normal/mod.rs
+++ b/backend/crates/headless-talk/src/channel/normal/mod.rs
@@ -104,7 +104,7 @@ pub(super) async fn load_list_profile(
 ) -> Result<ListChannelProfile, PoolTaskError> {
     let id = row.id;
 
-    let (name, image_url) = pool
+    let (name, image_meta) = pool
         .spawn(move |conn| {
             let name: Option<String> = channel_meta::table
                 .filter(
@@ -138,7 +138,10 @@ pub(super) async fn load_list_profile(
             .join(", ")
     });
 
-    Ok(ListChannelProfile { name, image_url })
+    Ok(ListChannelProfile {
+        name,
+        image: image_meta.and_then(|meta| serde_json::from_str(&meta).ok()),
+    })
 }
 
 pub(crate) async fn load_channel(

--- a/frontend/src/api/_types/chat.ts
+++ b/frontend/src/api/_types/chat.ts
@@ -60,7 +60,10 @@ export type ChannelListItem = {
   },
 
   name?: string;
-  profile?: string;
+  profile?: {
+    imageUrl: string;
+    fullImageUrl: string;
+  };
 
   unreadCount: number;
 

--- a/frontend/src/api/_types/chat.ts
+++ b/frontend/src/api/_types/chat.ts
@@ -49,7 +49,7 @@ export type ListUserProfile = {
 export type ChannelListItem = {
   channelType: string;
 
-  displayUsers: [string, ListUserProfile][],
+  displayUsers: ListUserProfile[],
 
   lastChat?: {
     profile: ListUserProfile,

--- a/frontend/src/pages/main/channel/_hooks/useChannelList.ts
+++ b/frontend/src/pages/main/channel/_hooks/useChannelList.ts
@@ -21,7 +21,7 @@ export const useChannelList = (): Accessor<ChannelListItem[]> => {
       for (const [id, item] of await getChannelList()) {
         result.push({
           id,
-          name: item.name ?? item.displayUsers.map(([, user]) => user.nickname).join(', '),
+          name: item.name ?? item.displayUsers.map((user) => user.nickname).join(', '),
           displayUsers: item.displayUsers,
           lastChat: item.lastChat ? {
             ...item.lastChat,

--- a/frontend/src/pages/main/channel/_hooks/useChannelList.ts
+++ b/frontend/src/pages/main/channel/_hooks/useChannelList.ts
@@ -29,7 +29,11 @@ export const useChannelList = (): Accessor<ChannelListItem[]> => {
           } : undefined,
           userCount: item.userCount,
           unreadCount: item.unreadCount,
-          profile: item.profile?.imageUrl,
+          profile:
+            item.profile?.imageUrl ??
+            (item.displayUsers.length === 1 ?
+              item.displayUsers[0].profileUrl :
+              undefined),
           silent: false, // TODO
         });
       }

--- a/frontend/src/pages/main/channel/_hooks/useChannelList.ts
+++ b/frontend/src/pages/main/channel/_hooks/useChannelList.ts
@@ -29,7 +29,7 @@ export const useChannelList = (): Accessor<ChannelListItem[]> => {
           } : undefined,
           userCount: item.userCount,
           unreadCount: item.unreadCount,
-          profile: item.profile,
+          profile: item.profile?.imageUrl,
           silent: false, // TODO
         });
       }

--- a/frontend/src/pages/main/channel/_types/channel-list-item.ts
+++ b/frontend/src/pages/main/channel/_types/channel-list-item.ts
@@ -7,7 +7,7 @@ export type ChannelListItem = {
   id: string;
   name: string;
 
-  displayUsers: [string, ListProfile][];
+  displayUsers: ListProfile[];
 
   lastChat?: {
     profile?: ListProfile,

--- a/frontend/src/pages/main/channel/chat/page.tsx
+++ b/frontend/src/pages/main/channel/chat/page.tsx
@@ -144,7 +144,7 @@ export const ChatPage = () => {
       <Show when={channelId()} fallback={<ChatEmpty />}>
         <ChannelHeader
           name={channelInfo()?.name ?? '...'}
-          profile={channelInfo()?.profile}
+          profile={channelInfo()?.profile?.imageUrl}
           members={channelInfo()?.userCount ?? 0}
         />
         <ChatFactoryContext.Provider value={channelFactory}>

--- a/frontend/src/pages/main/channel/chat/page.tsx
+++ b/frontend/src/pages/main/channel/chat/page.tsx
@@ -144,7 +144,10 @@ export const ChatPage = () => {
       <Show when={channelId()} fallback={<ChatEmpty />}>
         <ChannelHeader
           name={channelInfo()?.name ?? '...'}
-          profile={channelInfo()?.profile?.imageUrl}
+          profile={channelInfo()?.profile?.imageUrl ??
+            (channelInfo()?.displayUsers.length === 1 ?
+              channelInfo()?.displayUsers[0].profileUrl :
+              undefined)}
           members={channelInfo()?.userCount ?? 0}
         />
         <ChatFactoryContext.Provider value={channelFactory}>


### PR DESCRIPTION
## Description

<!--
Write description of PR here. If you're fixing a specific issue, write "Fixes #xxxx".
-->
#2157 을 대체합니다.

1:1 채팅의 프로필 이미지가 비어 있을 경우, 채팅 상대의 프로필 이미지를 대신 사용합니다.
또한, 기존에 채널 프로필 정보 내 이미지 메타데이터를 정상적으로 디코딩하지 못하고 있던 문제와,
IPC 포맷 변경 이후 FE 측 타입이 업데이트되지 않았던 부분을 수정합니다.

## Changelog

<!--
(Optional)

If this PR is not bug fixes, write list of changes here.
-->
1:1 채팅의 프로필 이미지가 비어 있을 경우, 채팅 상대의 프로필 이미지를 대신 사용합니다.

## Migration

<!--
(Optional)

If this PR contains breaking changes, describe migration guide.
- Fixing unintended behaviour is not a breaking changes.
- Adding new functionality is not a breaking change.
-->