### PR TITLE
채팅방 유저 참가, 나가기 동기화

### DIFF
--- a/backend/bin/client/src/handler.rs
+++ b/backend/bin/client/src/handler.rs
@@ -108,6 +108,8 @@ async fn handle_channel_event(
                 }))
                 .await;
         }
+
+        _ => {}
     }
 
     Ok(())

--- a/backend/crates/headless-talk/src/event/channel.rs
+++ b/backend/crates/headless-talk/src/event/channel.rs
@@ -24,6 +24,8 @@ pub enum ChannelEvent {
     Added {
         chatlog: Option<Chatlog>,
     },
-
     Left,
+
+    UserJoin(Chatlog),
+    UserLeft(Chatlog),
 }

--- a/backend/crates/talk-loco-client/src/client/media/io.rs
+++ b/backend/crates/talk-loco-client/src/client/media/io.rs
@@ -149,7 +149,7 @@ impl<T: AsyncWrite> AsyncWrite for MediaSink<T> {
 #[derive(Debug, Clone, Deserialize)]
 pub struct CompleteRes {
     #[serde(rename = "chatLog")]
-    pub chat_log: Option<Chatlog>,
+    pub chatlog: Option<Chatlog>,
 }
 
 #[derive(Debug, Error)]

--- a/backend/crates/talk-loco-client/src/talk/session/channel/info.rs
+++ b/backend/crates/talk-loco-client/src/talk/session/channel/info.rs
@@ -25,7 +25,7 @@ pub struct ChannelInfo {
     pub last_seen_log_id: i64,
 
     #[serde(rename = "lastChatLog")]
-    pub last_chat_log: Option<Chatlog>,
+    pub last_chatlog: Option<Chatlog>,
 
     #[serde(rename = "pushAlert")]
     pub push_alert: bool,

--- a/backend/crates/talk-loco-client/src/talk/stream/command.rs
+++ b/backend/crates/talk-loco-client/src/talk/stream/command.rs
@@ -85,7 +85,7 @@ pub struct SyncJoin {
 /// Sync chat delete
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct SyncDlMsg {
-    /// Deleted chat
+    /// Deleted chat feed
     #[serde(rename = "chatLog")]
     pub chatlog: Chatlog,
 }
@@ -140,7 +140,7 @@ pub struct SyncLinkPf {
 pub struct SyncRewr {
     /// Chatlog
     #[serde(rename = "chatLog")]
-    pub chat_log: Chatlog,
+    pub chatlog: Chatlog,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
@@ -150,4 +150,22 @@ pub struct Left {
 
     #[serde(rename = "lastTokenId")]
     pub last_token_id: i64,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct NewMem {
+    #[serde(rename = "chatId")]
+    pub chat_id: i64,
+
+    #[serde(rename = "chatLog")]
+    pub chatlog: Chatlog,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct DelMem {
+    #[serde(rename = "chatId")]
+    pub chat_id: i64,
+
+    #[serde(rename = "chatLog")]
+    pub chatlog: Chatlog,
 }

--- a/backend/crates/talk-loco-client/src/talk/stream/mod.rs
+++ b/backend/crates/talk-loco-client/src/talk/stream/mod.rs
@@ -1,7 +1,8 @@
 pub mod command;
 
 use self::command::{
-    ChgMeta, DecunRead, Left, Msg, SyncDlMsg, SyncJoin, SyncLinkCr, SyncLinkPf, SyncMemT, SyncRewr,
+    ChgMeta, DecunRead, DelMem, Left, Msg, NewMem, SyncDlMsg, SyncJoin, SyncLinkCr, SyncLinkPf,
+    SyncMemT, SyncRewr,
 };
 use command::Kickout;
 use futures_loco_protocol::loco_protocol::command::BoxedCommand;
@@ -76,5 +77,8 @@ create_enum!(
         "SYNCLINKPR" => SyncLinkProfile(SyncLinkPf),
 
         "LEFT" => Left(Left),
+
+        "NEWMEM" => NewUser(NewMem),
+        "DELMEM" => DelUser(DelMem),
     }
 );


### PR DESCRIPTION
## Description
채팅방에서 유저가 들어오고 나갈때 이벤트를 구현합니다.
<!--
Write description of PR here. If you're fixing a specific issue, write "Fixes #xxxx".
-->

## Changelog
* `NEWMEM` StreamCommand에 추가
* `DELMEM` StreamCommand에 추가
<!--
(Optional)

If this PR is not bug fixes, write list of changes here.
-->

## Migration

<!--
(Optional)

If this PR contains breaking changes, describe migration guide.
- Fixing unintended behaviour is not a breaking changes.
- Adding new functionality is not a breaking change.
-->