### PR TITLE
Translations

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,0 +1,32 @@
+name: Prettier
+
+on:
+  pull_request:
+    paths:
+      - '**.json'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  prettier:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Install dependencies
+        run: pnpm install --dev
+
+      - name: Prettify code
+        uses: creyD/prettier_action@v4.3
+        with:
+          # This part is also where you can pass other options, for example:
+          prettier_options: --check frontend/src/assets/translations/*.json
+          prettier_plugins: prettier-plugin-sort-json
+          dry: true

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
+# Ignore package-lock; we use pnpm
+package-lock.json
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+    "plugins": [
+        "prettier-plugin-sort-json"
+    ],
+    "jsonRecursiveSort": true
+}

--- a/frontend/src/assets/translations/en-US.json
+++ b/frontend/src/assets/translations/en-US.json
@@ -4,7 +4,8 @@
     "cancel": "Cancel",
     "close": "Close",
     "prev": "Previous",
-    "next": "Next"
+    "next": "Next",
+    "unknown": "Unknown"
   },
   "login": {
     "title": "Sign in with Kakao Account",
@@ -37,9 +38,9 @@
     "unknown_error": "An unknown error has occurred. {{detail}}",
     "status": {
       "login": {
-        "500": "An internal error has occurred",
         "30": "Account information is incorrect",
         "32": "Account does not exist",
+        "500": "An internal error has occurred",
         "-16": "Account information is incorrect",
         "-100": "Unregistered device",
         "-101": "Already connected to another device",
@@ -83,9 +84,24 @@
     },
     "chat": {
       "empty": {
-        "chat": "Select a chat room to start a conversation.",
-        "friend": "Kiwi bird is waiting for friends."
-      }
+        "title": "Kiwi is waiting to talk to friends",
+        "subtitle": "Start a new conversation"
+      },
+      "member_count": "{{count}} people",
+      "placeholder": "Send a message...",
+      "attachment": {
+        "audio": "Audio",
+        "binary": "Executable",
+        "document": "Document",
+        "file": "File",
+        "image": "Image",
+        "presentation": "Presentation",
+        "spreadsheet": "Spreadsheet",
+        "text": "Text",
+        "video": "Video"
+      },
+      "first_chat": "",
+      "show_more": "Show more"
     },
     "friend": {
       "all_friends": "All Friends",

--- a/frontend/src/assets/translations/en-US.json
+++ b/frontend/src/assets/translations/en-US.json
@@ -1,94 +1,77 @@
 {
   "common": {
-    "ok": "Ok",
     "cancel": "Cancel",
     "close": "Close",
-    "prev": "Previous",
     "next": "Next",
+    "ok": "Ok",
+    "prev": "Previous",
     "unknown": "Unknown"
   },
   "login": {
-    "title": "Sign in with Kakao Account",
-    "register_title": "Device Authentication",
+    "add_account": "Add a New Account",
+    "auto_login_on_launch": "Automatic sign-in on Launch",
+    "end_caption_subtitle": "Press 'Start' to take the first step in the 'universal communication' protocol",
+    "end_caption_title": "All preparations are now complete",
+    "end_title": "Start",
+    "generic_error": "An internal error has occurred.",
+    "id_placeholder": "Kakao Account (Email or Phone Number)",
     "login": "Sign in",
     "login_name": "Sign in to {{name}}",
     "logout": "Sign out",
-    "id_placeholder": "Kakao Account (Email or Phone Number)",
-    "password_placeholder": "Password",
     "manage_account": "Manage Account",
-    "add_account": "Add a New Account",
-    "save_id": "Save ID",
-    "auto_login_on_launch": "Automatic sign-in on Launch",
-    "register_type": {
-      "permanent": "Authenticate My PC",
-      "temporary": "Receive One-time Authentication"
-    },
+    "passcode_placeholder": "Enter Registration Code",
+    "passcode_tip": "KakaoTalk App: Settings > Privacy > Manage Devices",
+    "password_placeholder": "Password",
     "reason": {
-      "required_id_password": "Please enter your account ID and password.",
       "auto_login_failed": {
         "file_read": "An error occurred while reading the stored account information",
         "general": "Automatic sign-in has failed"
       },
-      "kickout": "Logged out due to access from another device"
+      "kickout": "Logged out due to access from another device",
+      "required_id_password": "Please enter your account ID and password."
     },
-    "passcode_tip": "KakaoTalk App: Settings > Privacy > Manage Devices",
-    "passcode_placeholder": "Enter Registration Code",
+    "register_title": "Device Authentication",
+    "register_type": {
+      "permanent": "Authenticate My PC",
+      "temporary": "Receive One-time Authentication"
+    },
+    "result": {},
+    "save_id": "Save ID",
     "set_forced": "Upon re-login, the connection on other devices will be terminated.",
-    "generic_error": "An internal error has occurred.",
-    "unknown_error": "An unknown error has occurred. {{detail}}",
+    "start": "Start",
     "status": {
+      "device_register": {
+        "-112": "Exceeded the number of daily registration attempts."
+      },
       "login": {
-        "30": "Account information is incorrect",
-        "32": "Account does not exist",
-        "500": "An internal error has occurred",
-        "-16": "Account information is incorrect",
         "-100": "Unregistered device",
         "-101": "Already connected to another device",
         "-102": "Exceeded the number of devices that can be authenticated",
         "-110": "UUID is not Base64 encoded",
         "-111": "Registration number is incorrect",
         "-125": "Already registered with another device",
+        "-16": "Account information is incorrect",
         "-500": "API request failed",
         "-910": "Invalid login token",
         "-950": "Invalid access token",
+        "-9797": "Server is under maintenance",
         "-997": "Account is blocked",
         "-998": "Registration is required",
         "-999": "Client version is too low",
-        "-9797": "Server is under maintenance"
-      },
-      "device_register": {
-        "-112": "Exceeded the number of daily registration attempts."
+        "30": "Account information is incorrect",
+        "32": "Account does not exist",
+        "500": "An internal error has occurred"
       },
       "passcode": {
-        "-111": "Registration number is incorrect",
-        "-102": "Exceeded the number of devices that can be registered. The maximum number of devices that can be registered is 5."
+        "-102": "Exceeded the number of devices that can be registered. The maximum number of devices that can be registered is 5.",
+        "-111": "Registration number is incorrect"
       }
     },
-    "result": {},
-    "end_title": "Start",
-    "end_caption_title": "All preparations are now complete",
-    "end_caption_subtitle": "Press 'Start' to take the first step in the 'universal communication' protocol",
-    "start": "Start"
+    "title": "Sign in with Kakao Account",
+    "unknown_error": "An unknown error has occurred. {{detail}}"
   },
   "main": {
-    "menu": {
-      "chat": {
-        "name": "Chat",
-        "normal_chat": "Normal Chat",
-        "open_chat": "Open Chat"
-      },
-      "friend": {
-        "name": "Friends",
-        "channel": "Channel"
-      }
-    },
     "chat": {
-      "empty": {
-        "title": "Kiwi is waiting to talk to friends",
-        "subtitle": "Start a new conversation"
-      },
-      "member_count": "{{count}} people",
-      "placeholder": "Send a message...",
       "attachment": {
         "audio": "Audio",
         "binary": "Executable",
@@ -100,19 +83,36 @@
         "text": "Text",
         "video": "Video"
       },
+      "empty": {
+        "subtitle": "Start a new conversation",
+        "title": "Kiwi is waiting to talk to friends"
+      },
       "first_chat": "",
+      "member_count": "{{count}} people",
+      "placeholder": "Send a message...",
       "show_more": "Show more"
     },
     "friend": {
       "all_friends": "All Friends",
-      "pinned_friends": "Pinned Friends",
+      "me": "Me",
       "near_birthday_friends": "Friends with Upcoming Birthdays",
-      "me": "Me"
+      "pinned_friends": "Pinned Friends"
+    },
+    "menu": {
+      "chat": {
+        "name": "Chat",
+        "normal_chat": "Normal Chat",
+        "open_chat": "Open Chat"
+      },
+      "friend": {
+        "channel": "Channel",
+        "name": "Friends"
+      }
     }
   },
   "window-controls": {
-    "minimize": "Minimize",
+    "close": "Close",
     "maximize": "Maximize",
-    "close": "Close"
+    "minimize": "Minimize"
   }
 }

--- a/frontend/src/assets/translations/ko-KR.json
+++ b/frontend/src/assets/translations/ko-KR.json
@@ -1,76 +1,103 @@
 {
   "common": {
-    "ok": "확인",
     "cancel": "취소",
     "close": "닫기",
-    "prev": "이전으로",
     "next": "다음으로",
+    "ok": "확인",
+    "prev": "이전으로",
     "unknown": "알 수 없음"
   },
   "login": {
-    "title": "카카오 계정으로 로그인",
-    "register_title": "기기 인증",
+    "add_account": "새로운 계정 추가",
+    "auto_login_on_launch": "실행 시 자동 로그인",
+    "end_caption_subtitle": "시작하기를 눌러 전우주 통신규약의 첫걸음을 내딛으세요",
+    "end_caption_title": "이제 모든 준비가\n끝났습니다",
+    "end_title": "시작",
+    "generic_error": "내부 에러가 발생했습니다.",
+    "id_placeholder": "카카오 계정 (이메일 또는 전화번호)",
     "login": "로그인",
     "login_name": "{{name}} 로그인",
     "logout": "로그아웃",
-    "id_placeholder": "카카오 계정 (이메일 또는 전화번호)",
-    "password_placeholder": "비밀번호",
     "manage_account": "계정 관리",
-    "add_account": "새로운 계정 추가",
-    "save_id": "아이디 저장",
-    "auto_login_on_launch": "실행 시 자동 로그인",
-    "register_type": {
-      "permanent": "내 PC 인증 받기",
-      "temporary": "일회용 인증 받기"
-    },
+    "passcode_placeholder": "인증코드 입력",
+    "passcode_tip": "카카오톡 앱 : 설정 > 개인/보안 > PC연결관리",
+    "password_placeholder": "비밀번호",
     "reason": {
-      "required_id_password": "아이디와 비밀번호를 입력해 주세요.",
       "auto_login_failed": {
         "file_read": "저장된 계정 정보를 읽는 중 오류가 발생했습니다",
         "general": "자동 로그인이 실패했습니다"
       },
-      "kickout": "다른 기기 접속으로 인해 로그아웃되었습니다"
+      "kickout": "다른 기기 접속으로 인해 로그아웃되었습니다",
+      "required_id_password": "아이디와 비밀번호를 입력해 주세요."
     },
-    "passcode_tip": "카카오톡 앱 : 설정 > 개인/보안 > PC연결관리",
-    "passcode_placeholder": "인증코드 입력",
+    "register_title": "기기 인증",
+    "register_type": {
+      "permanent": "내 PC 인증 받기",
+      "temporary": "일회용 인증 받기"
+    },
+    "result": {},
+    "save_id": "아이디 저장",
     "set_forced": "다시 로그인 시 다른 기기의 연결을 해제합니다.",
-    "generic_error": "내부 에러가 발생했습니다.",
-    "unknown_error": "알 수 없는 에러가 발생했습니다. {{detail}}",
+    "start": "시작하기",
     "status": {
+      "device_register": {
+        "-112": "일일 인증 시도 횟수를 초과했습니다."
+      },
       "login": {
-        "500": "내부 오류가 발생했습니다",
-        "30": "계정 정보가 올바르지 않습니다",
-        "32": "계정이 존재하지 않습니다",
-        "-16": "계정 정보가 올바르지 않습니다",
         "-100": "등록되지 않은 기기입니다",
         "-101": "이미 다른 기기에 접속되어 있습니다.",
         "-102": "인증 가능한 기기의 개수를 초과했습니다",
         "-110": "UUID가 Base64 인코딩 되어있지 않습니다",
         "-111": "인증 번호가 올바르지 않습니다",
         "-125": "이미 다른 기기로 가입되어 있습니다",
+        "-16": "계정 정보가 올바르지 않습니다",
         "-500": "API 요청 실패",
         "-910": "올바르지 않은 로그인 토큰입니다",
         "-950": "올바르지 않은 액세스 토큰입니다",
+        "-9797": "서버 점검 중입니다",
         "-997": "차단된 계정입니다",
         "-998": "인증이 필요합니다",
         "-999": "클라이언트 버전이 너무 낮습니다",
-        "-9797": "서버 점검 중입니다"
-      },
-      "device_register": {
-        "-112": "일일 인증 시도 횟수를 초과했습니다."
+        "30": "계정 정보가 올바르지 않습니다",
+        "32": "계정이 존재하지 않습니다",
+        "500": "내부 오류가 발생했습니다"
       },
       "passcode": {
-        "-111": "인증번호가 올바르지 않습니다",
-        "-102": "등록 가능한 기기 갯수를 초과했습니다. 등록 가능한 기기는 최대 5대 입니다."
+        "-102": "등록 가능한 기기 갯수를 초과했습니다. 등록 가능한 기기는 최대 5대 입니다.",
+        "-111": "인증번호가 올바르지 않습니다"
       }
     },
-    "result": {},
-    "end_title": "시작",
-    "end_caption_title": "이제 모든 준비가\n끝났습니다",
-    "end_caption_subtitle": "시작하기를 눌러 전우주 통신규약의 첫걸음을 내딛으세요",
-    "start": "시작하기"
+    "title": "카카오 계정으로 로그인",
+    "unknown_error": "알 수 없는 에러가 발생했습니다. {{detail}}"
   },
   "main": {
+    "chat": {
+      "attachment": {
+        "audio": "음악",
+        "binary": "실행 파일",
+        "document": "문서",
+        "file": "파일",
+        "image": "이미지",
+        "presentation": "프레젠테이션",
+        "spreadsheet": "스프레드 시트",
+        "text": "텍스트",
+        "video": "동영상"
+      },
+      "empty": {
+        "subtitle": "친구와 새로운 대화를 시작해보세요",
+        "title": "키위새는 대화할 친구를 기다리고 있어요"
+      },
+      "first_chat": "채팅창의 첫부분 입니다",
+      "member_count": "{{count}}명",
+      "placeholder": "메시지 보내기...",
+      "show_more": "더보기"
+    },
+    "friend": {
+      "all_friends": "전체 친구",
+      "me": "나",
+      "near_birthday_friends": "생일이 가까운 친구",
+      "pinned_friends": "고정된 친구"
+    },
     "menu": {
       "chat": {
         "name": "채팅",
@@ -78,41 +105,14 @@
         "open_chat": "오픈채팅"
       },
       "friend": {
-        "name": "친구",
-        "channel": "채널"
+        "channel": "채널",
+        "name": "친구"
       }
-    },
-    "chat": {
-      "empty": {
-        "title": "키위새는 대화할 친구를 기다리고 있어요",
-        "subtitle": "친구와 새로운 대화를 시작해보세요"
-      },
-      "member_count": "{{count}}명",
-      "placeholder": "메시지 보내기...",
-      "first_chat": "채팅창의 첫부분 입니다",
-      "show_more": "더보기",
-      "attachment": {
-        "image": "이미지",
-        "video": "동영상",
-        "audio": "음악",
-        "spreadsheet": "스프레드 시트",
-        "presentation": "프레젠테이션",
-        "document": "문서",
-        "text": "텍스트",
-        "binary": "실행 파일",
-        "file": "파일"
-      }
-    },
-    "friend": {
-      "all_friends": "전체 친구",
-      "pinned_friends": "고정된 친구",
-      "near_birthday_friends": "생일이 가까운 친구",
-      "me": "나"
     }
   },
   "window-controls": {
-    "minimize": "최소화",
+    "close": "닫기",
     "maximize": "최대화",
-    "close": "닫기"
+    "minimize": "최소화"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "frontend:build": "tsc && vite build",
     "frontend:preview": "vite preview",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "lint": "prettier --write frontend/src/assets/translations/*.json"
   },
   "repository": {
     "type": "git",
@@ -33,6 +34,8 @@
     "eslint": "8.54.0",
     "eslint-config-google": "0.14.0",
     "eslint-plugin-storybook": "0.6.15",
+    "prettier": "^3.1.0",
+    "prettier-plugin-sort-json": "^3.1.0",
     "storybook": "7.5.3",
     "storybook-solidjs": "1.0.0-beta.2",
     "storybook-solidjs-vite": "1.0.0-beta.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,12 @@ devDependencies:
   eslint-plugin-storybook:
     specifier: 0.6.15
     version: 0.6.15(eslint@8.54.0)(typescript@5.3.2)
+  prettier:
+    specifier: ^3.1.0
+    version: 3.1.0
+  prettier-plugin-sort-json:
+    specifier: ^3.1.0
+    version: 3.1.0(prettier@3.1.0)
   storybook:
     specifier: 7.5.3
     version: 7.5.3
@@ -7308,9 +7314,24 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
+  /prettier-plugin-sort-json@3.1.0(prettier@3.1.0):
+    resolution: {integrity: sha512-eIDEUjwzekiVd+oKrpd0aoACBTp5zOW71wDTNy+qQ5C9Q8oqt9n9wCm4F+SeRZbXfgblh/WYIguJynImlBXrvQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      prettier: ^3.0.0
+    dependencies:
+      prettier: 3.1.0
+    dev: true
+
   /prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
+    hasBin: true
+    dev: true
+
+  /prettier@3.1.0:
+    resolution: {integrity: sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==}
+    engines: {node: '>=14'}
     hasBin: true
     dev: true
 


### PR DESCRIPTION
## Description

I added prettier to run this sorting behavior, so just running `pnpm run lint` should be enough.

## Changelog

```
    translations: Update English strings.
    
    The newly added or modified keys have been inserted in their
    alphabetically correct place in the file, making the diff larger
    than it should have been. The follow-up commits will set in place
    a sorting system such that this doesn't happen again.

---

    translations: Bulk sort all JSON keys.
    
    This should help with easy diffing as well as easy use of automated tools
    like i18n-ally, etc. Ideally, we also want a linting rule that automatically
    sorts the keys on commit, or throws a linting error, so this commit is just
    half the solution for that.

---

    devtools: Add prettier to autosort translation keys.
    
    We can later expand our usage of prettier by enabling options/files
    as we go along.
```

## Migration

<!--
(Optional)

If this PR contains breaking changes, describe migration guide.
- Fixing unintended behaviour is not a breaking changes.
- Adding new functionality is not a breaking change.
-->