### PR TITLE
chore(deps): update `time` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2871,6 +2871,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4956,13 +4962,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.30"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa 1.0.9",
  "libc",
+ "num-conv",
  "num_threads",
  "powerfmt",
  "serde",
@@ -4978,10 +4985,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 


### PR DESCRIPTION


## Description

This fixes compilation with Rust 1.80

References:
- https://github.com/NixOS/nixpkgs/issues/332957
- https://github.com/rust-lang/rust/issues/125319
- https://internals.rust-lang.org/t/type-inference-breakage-in-1-80-has-not-been-handled-well/21374

## Changelog

<!--
(Optional)

If this PR is not bug fixes, write list of changes here.
-->

Bump the `time` crate

## Migration

<!--
(Optional)

If this PR contains breaking changes, describe migration guide.
- Fixing unintended behaviour is not a breaking changes.
- Adding new functionality is not a breaking change.
-->